### PR TITLE
Memory leak fixes for file handling.

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -206,6 +206,12 @@ class AGraph(object):
         self.node_attr=Attribute(self.handle,1)  # default node attributes
         self.edge_attr=Attribute(self.handle,2)  # default edge attribtes
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, ext_type, exc_value, traceback):
+        self.close()
+
     def __str__(self):
         return unicode(self).encode(self.encoding,'replace')
 
@@ -1169,6 +1175,8 @@ class AGraph(object):
         """
         fh=self._get_fh(path)
         try:
+            if self.handle is not None:
+                gv.agclose(self.handle)
             self.handle = gv.agread(fh,None)
         except IOError:
             print "IO error reading file"


### PR DESCRIPTION
The read() method has a memory leak.  There are two issues to address.

1) Added explicit agclose() to obsolete file handle in  AGraph.read() method
2) User must explicitly call AGraph.close() or else use a a context manager (now enabled)

To process many files without a leak you can do one of the following:

``` python
import pygraphviz
for i in range(1000000):
    A = pygraphviz.AGraph()
    A.read('foo.dot')
    A.close()
```

``` python
import pygraphviz
for i in range(1000000):
    with pygraphviz.AGraph() as A:
        A.read('foo.dot')
```
