### PR TITLE
Import version.py as a relative import rather than absolute

### DIFF
--- a/pygraphviz/__init__.py
+++ b/pygraphviz/__init__.py
@@ -35,7 +35,7 @@ if release.revision is None:
     # we probably not running in an svn directory   
     try:
         # use release data stored at installatation time.
-        import version
+        from . import version
         __version__ = version.__version__
         __revision__ = version.__revision__
         __date__ = version.__date__


### PR DESCRIPTION
This fixes netxorkx breakage with python 3: https://github.com/pygraphviz/pygraphviz/issues/16#issuecomment-49565803
