### PR TITLE
Installation fix for Py3

### DIFF
--- a/setup_extra.py
+++ b/setup_extra.py
@@ -47,7 +47,7 @@ def pkg_config():
             include_path=output.strip()[2:]
     except:
         print("Failed to find pkg-config")
-    return include_path,library_path
+    return b(include_path),b(library_path)
 
 def dotneato_config():
     # find graphviz configuration with dotneato-config


### PR DESCRIPTION
Installing from git to use the Python 3 version of pygraphviz was bringing up:

```
TypeError: Can't convert 'bytes' object to str implicitly
```

Because the library directory as returned was in bytes format. This PR should convert it to unicode if using Python 3.
