### PR TITLE
Convert binary Popen output into str

### DIFF
--- a/setup_extra.py
+++ b/setup_extra.py
@@ -10,6 +10,7 @@ Setup helpers for PyGraphviz.
 #    Distributed with BSD license.     
 #    All rights reserved, see LICENSE for details.
 import os
+import sys
 
 def pkg_config():
     # attempt to find graphviz installation with pkg-config
@@ -29,13 +30,14 @@ def pkg_config():
                    S.Popen('pkg-config --libs-only-L libcgraph',
                            shell=True, stdin=S.PIPE, stdout=S.PIPE,
                            close_fds=True).communicate()
-        output = output.decode("utf-8")
+        output = output.decode(sys.stdout.encoding)
         if output:
             library_path=output.strip()[2:]
         output,err = \
                    S.Popen('pkg-config --cflags-only-I libcgraph',
                            shell=True, stdin=S.PIPE, stdout=S.PIPE,
                            close_fds=True).communicate()
+        output = output.decode(sys.stdout.encoding)
         if output:
             include_path=output.strip()[2:]
     except:


### PR DESCRIPTION
I tried install pygraphviz with Python 3.4 on OS X and eventually I got error in distutils.

```
  File "/usr/local/Cellar/python3/3.4.1_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/unixccompiler.py", line 205, in library_dir_option
    return "-L" + dir
TypeError: Can't convert 'bytes' object to str implicitly
```

This fix helps to install it correctly (works both Python 3.4.1 and Python 2.7.6 )
