### PR TITLE
Use graphviz subgraph node/edge calls

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -1023,10 +1023,13 @@ class AGraph(object):
         if nbunch is None: return H
         # add induced subgraph on nodes in nbunch
         bunch = self.prepare_nbunch(nbunch)
-        H.add_nodes_from(bunch)
-        for (u, v) in self.edges():
+        for n in bunch:
+            node = Node(self, n)
+            nh = gv.agsubnode(self.handle, node.handle, _Action.create)
+        for (u, v, k) in self.edges(keys=True):
             if u in H and v in H:
-                H.add_edge(u, v)
+                edge = Edge(self, u, v, k)
+                eh = gv.agsubedge(self.handle, edge.handle, _Action.create)
 
         return H
 


### PR DESCRIPTION
Subgraphs should use agsubnode and agsubedge to avoid creating new nodes and edges in the graph.

Addresses #28
