### PR TITLE
Simplify setup_extra.py

### DIFF
--- a/setup_extra.py
+++ b/setup_extra.py
@@ -3,77 +3,61 @@
 """
 Setup helpers for PyGraphviz.
 """
-#    Copyright (C) 2006-2010 by 
+#    Copyright (C) 2006-2010 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Manos Renieris, http://www.cs.brown.edu/~er/
-#    Distributed with BSD license.     
+#    Distributed with BSD license.
 #    All rights reserved, see LICENSE for details.
+
+from __future__ import print_function
 import os
 import sys
+import subprocess as S
 
 def pkg_config():
     # attempt to find graphviz installation with pkg-config
     # should work with modern versions of graphviz
-    try:
-        import subprocess as S
-    except ImportError:
-        print("""-- Missing subprocess package:
-        Install subprocess from
-        http://effbot.org/downloads/#subprocess
-        or set the graphviz paths manually as described below.""")
 
     library_path=None
     include_path=None
     try:
-        output,err = \
-                   S.Popen('pkg-config --libs-only-L libcgraph',
-                           shell=True, stdin=S.PIPE, stdout=S.PIPE,
-                           close_fds=True).communicate()
-        output = output.decode(sys.stdout.encoding)
-        if output:
-            library_path=output.strip()[2:]
-        output,err = \
-                   S.Popen('pkg-config --cflags-only-I libcgraph',
-                           shell=True, stdin=S.PIPE, stdout=S.PIPE,
-                           close_fds=True).communicate()
-        output = output.decode(sys.stdout.encoding)
-        if output:
-            include_path=output.strip()[2:]
-    except:
+        output = S.check_output(['pkg-config', '--libs-only-L', 'libcgraph'])
+        library_path = output.strip()[2:]
+
+        output = S.check_output(['pkg-config', '--cflags-only-I',
+            'libcgraph'])
+        include_path = output.strip()[2:]
+    except S.CalledProcessError:
         print("Failed to find pkg-config")
-    return include_path,library_path
+
+    return include_path, library_path
 
 def dotneato_config():
     # find graphviz configuration with dotneato-config
     # works with older versions of graphviz
-    # attempt to find graphviz installation with pkg-config
-    # should work with modern versions of graphviz
+
+    library_path = None
+    include_path = None
     try:
-        import subprocess as S
-    except ImportError:
-        print("""-- Missing subprocess package:
-        Install subprocess from
-        http://effbot.org/downloads/#subprocess
-        or set the graphviz paths manually as described below.""")
-    library_path=None
-    include_path=None
+        output = S.check_output(['dotneato-config', '--ldflags', '--cflags'])
+        include_path, library_path = output.split()
+        library_path = library_path.strip()[2:]
+        include_path = include_path.strip()[2:]
+    except S.CalledProcessError:
+        print("Failed to find dotneato-config")
+        # fall through and test the other syntax
+    else:
+        return include_path, library_path
+
     try:
-        output = S.Popen(['dotneato-config','--ldflags','--cflags'],
-                         stdout=S.PIPE).communicate()[0]
-        if output:
-            include_path,library_path=output.split()
-            library_path=library_path.strip()[2:]
-            include_path=include_path.strip()[2:]
-        else:
-            output = S.Popen(['dotneato-config','--libs','--cflags'],
-                         stdout=S.PIPE).communicate()[0]
-            if output:
-                include_path,library_path=output.split('\n',1)
-                library_path=library_path.strip()[2:]
-                include_path=include_path.strip()[2:]
+        output = S.check_output(['dotneato-config', '--libs', '--cflags'])
+        include_path, library_path = output.split('\n', 1)
+        library_path = library_path.strip()[2:]
+        include_path = include_path.strip()[2:]
     except:
         print("Failed to find dotneato-config")
-    return include_path,library_path
 
+    # nothing else to try, just return
+    return include_path, library_path
 


### PR DESCRIPTION
Hey there,

I had some issues installing pygraphviz (even git master) and I ended up refactoring a bit `setup_extra.py`.

1. subprocess was added in python in version 2.4 so I guess we can take it for granted
2. also check_output is handy and the shell doesn't need to be involved
3. to maintain compatibility with python2 we should import `print_function` from the module `__future__` otherwise everything gets printed in parenthesis like it was a tuple.
4. the try...except block is a bit too broad, I had the problem discussed below and it was swallowed by the catch-all except. (I spent 10 minutes trying to find out why I didn't have the graphviz libraries installed, only to discover later that I did have them and the install script had a problem).

my issue was this 
```
Traceback (most recent call last):
  File "<string>", line 17, in <module>
  File "/var/folders/9x/fz874hx56nsbc8h3jlq1vv840000gp/T/pip-Vs2GGu-build/setup.py", line 62, in <module>
    include_dirs,library_dirs = pkg_config()
  File "setup_extra.py", line 35, in pkg_config
    output = output.decode(sys.stdout.encoding)
```

it seems that in python2 and using `pip install .` sys.stdout.encoding is None. Removing that line makes it work for me with both `pip install .` and `pip3 install .`.

So, I need to figure out how to deal correctly with the encoding, there's no need to marge this yet, let me leave it here :)

kudos for working on python3 support!
