### PR TITLE
Update INSTALL.txt

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -47,7 +47,7 @@ Source Archive File
 
   3. Run "python setup.py install" to build and install 
 
-  4. (optional) Run "python setup_egg.py nosetests" to execute the tests
+  4. (optional) Run "python setup.py test" to execute the tests
 
 
 Github
@@ -63,7 +63,7 @@ Github
 
   3.  Run "python setup.py install" to build and install
 
-  4. (optional) Run "python setup_egg.py nosetests" to execute the tests
+  4. (optional) Run "python setup.py test" to execute the tests
 
 
 If you don't have permission to install software on your


### PR DESCRIPTION
In INSTALL.txt:
"(optional) Run "python setup_egg.py nosetests" to execute the tests"
1. there is no target "nosetests". 
2. running python setup_egg.py test gives strange:
setup_egg.py: error: Error reading config file 'setup.cfg': no such option 'with-doctest-ignore-unicode'
Therefore I suppose setup_egg.py nosetests is obsolete (not-functional) and should be replaced by standard setup.py test

I'm not completely sure - pls. double check whether my hypothesis is correct