### PR TITLE
Convert line comment marker for latest swig

### DIFF
--- a/pygraphviz/graphviz.i
+++ b/pygraphviz/graphviz.i
@@ -1,9 +1,9 @@
-#    Copyright (C) 2004-2006 by 
-#    Aric Hagberg <hagberg@lanl.gov>
-#    Dan Schult <dschult@colgate.edu>
-#    Manos Renieris, http://www.cs.brown.edu/~er/
-#    Distributed with BSD license.     
-#    All rights reserved, see LICENSE for details.
+//    Copyright (C) 2004-2006 by 
+//    Aric Hagberg <hagberg@lanl.gov>
+//    Dan Schult <dschult@colgate.edu>
+//    Manos Renieris, http://www.cs.brown.edu/~er/
+//    Distributed with BSD license.     
+//    All rights reserved, see LICENSE for details.
 
 %module graphviz
 


### PR DESCRIPTION
in swig-3* a line starting with '#' raises a

Error: Unknown SWIG preprocessor directive

Exchanging the comment marker solves this.

Signed-off-by: Justin Lecher <jlec@gentoo.org>