### PR TITLE
Auto detect graphviz installation path on ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
   # We need GraphViz
   - "sudo apt-get install graphviz 2>&1 | tail -n 2"
 install:
+  - pip install mock
   - pip install nose
   - pip install doctest-ignore-unicode
   - pip install coveralls

--- a/pygraphviz/tests/test_setup.py
+++ b/pygraphviz/tests/test_setup.py
@@ -2,7 +2,7 @@ import sys
 sys.path.insert(0,'../..')
 import setup_extra
 from nose.tools import *
-from unittest.mock import patch
+from mock import patch
 
 
 def _get_values():

--- a/pygraphviz/tests/test_setup.py
+++ b/pygraphviz/tests/test_setup.py
@@ -1,0 +1,36 @@
+import sys
+sys.path.insert(0,'../..')
+import setup_extra
+from nose.tools import *
+from unittest.mock import patch
+
+
+def _get_values():
+    return None, 'library'
+
+
+def _get_dpkg_output():
+    s = bytes("""libgvc: /usr/local/include/graphviz/gvc.h
+                 gphviz: /usr/local/lib/graphviz/graphviz.so""", encoding='utf8')
+    return s
+
+
+def test_try():
+    i, l = None, None
+    i, l = setup_extra._try_configure(i, l, _get_values)
+    assert_equals(i, None)
+    assert_equals(l, 'library')
+
+
+@patch('subprocess.check_output')
+def test_dpkg_config(subprocess_mock):
+    subprocess_mock.return_value = _get_dpkg_output()
+    i, l = setup_extra._dpkg_config()
+    assert_equal(i, '/usr/local/include/graphviz')
+    assert_equal(l, '/usr/local/lib/graphviz')
+
+
+
+def test_b2str():
+    s = setup_extra._b2str(bytes('abc', encoding='utf8'))
+    assert_equal(s, u'abc')

--- a/pygraphviz/tests/test_setup.py
+++ b/pygraphviz/tests/test_setup.py
@@ -1,8 +1,13 @@
 import sys
-sys.path.insert(0,'../..')
-import setup_extra
 from nose.tools import *
 from mock import patch
+
+# inside distributed version, there is no setup_extra files already
+sys.path.insert(0,'../..')
+try:
+    setup_extra = __import__('setup_extra')
+except ImportError:
+    setup_extra = None
 
 
 def _get_values():
@@ -20,21 +25,27 @@ def _get_dpkg_output():
 
 
 def test_try():
-    i, l = None, None
-    i, l = setup_extra._try_configure(i, l, _get_values)
-    assert_equals(i, None)
-    assert_equals(l, 'library')
+    if setup_extra:
+        i, l = None, None
+        i, l = setup_extra._try_configure(i, l, _get_values)
+        assert_equals(i, None)
+        assert_equals(l, 'library')
 
 
 @patch('subprocess.check_output')
 def test_dpkg_config(subprocess_mock):
-    subprocess_mock.return_value = _get_dpkg_output()
-    i, l = setup_extra._dpkg_config()
-    assert_equal(i, '/usr/local/include/graphviz')
-    assert_equal(l, '/usr/local/lib/graphviz')
-
+    if setup_extra:
+        subprocess_mock.return_value = _get_dpkg_output()
+        i, l = setup_extra._dpkg_config()
+        assert_equal(i, '/usr/local/include/graphviz')
+        assert_equal(l, '/usr/local/lib/graphviz')
 
 
 def test_b2str():
-    s = setup_extra._b2str(bytes('abc', encoding='utf8'))
-    assert_equal(s, u'abc')
+    if setup_extra:
+        if sys.version_info >= (3, 0):
+            r = bytes('abc', encoding='utf8')
+        else:
+            r = str('abc')
+        s = setup_extra._b2str(r)
+        assert_equal(s, u'abc')

--- a/pygraphviz/tests/test_setup.py
+++ b/pygraphviz/tests/test_setup.py
@@ -10,8 +10,12 @@ def _get_values():
 
 
 def _get_dpkg_output():
-    s = bytes("""libgvc: /usr/local/include/graphviz/gvc.h
-                 gphviz: /usr/local/lib/graphviz/graphviz.so""", encoding='utf8')
+    r = """libgvc: /usr/local/include/graphviz/gvc.h
+                     gphviz: /usr/local/lib/graphviz/graphviz.so"""
+    if sys.version_info >= (3, 0):
+        s = bytes(r, encoding='utf8')
+    else:
+        s = str(r)
     return s
 
 

--- a/setup.py
+++ b/setup.py
@@ -84,5 +84,5 @@ if __name__ == "__main__":
         package_data=package_data,
         include_package_data = True,
         test_suite='nose.collector',
-        tests_require=['nose>=0.10.1', 'doctest-ignore-unicode>=0.1.0',],
+        tests_require=['nose>=0.10.1', 'doctest-ignore-unicode>=0.1.0', 'mock>=1.3'],
     )

--- a/setup_extra.py
+++ b/setup_extra.py
@@ -3,7 +3,7 @@
 """
 Setup helpers for PyGraphviz.
 """
-#    Copyright (C) 2006-2010 by 
+#    Copyright (C) 2006-2015 by
 #    Aric Hagberg <hagberg@lanl.gov>
 #    Dan Schult <dschult@colgate.edu>
 #    Manos Renieris, http://www.cs.brown.edu/~er/
@@ -14,6 +14,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import subprocess as S
 import sys
+import os
 
 
 def _b2str(buffer):
@@ -23,7 +24,7 @@ def _b2str(buffer):
         if not encoding:
             # can be run without stdout
             if sys.stdout and sys.stdout.encoding:
-                # encoding is nont None only staring Python 3.2
+                # encoding is not None only staring Python 3.2
                 encoding = sys.stdout.encoding
             else:
                 # fall back to default encoding ( normally it should not happen)
@@ -32,23 +33,50 @@ def _b2str(buffer):
             result = buffer.decode(encoding)
         return result
     else:
+        # in Python 2 conversion is implicit
         return buffer
+
+
+def _dpkg_config():
+    # attempt to find graphviz installation with pkg-config
+    # should work with modern versions of graphviz
+    include_dirs=None
+    library_dirs=None
+    
+    try:
+        output = S.check_output(['dpkg', '-S', 'graphviz'])
+        output = _b2str(output)
+        lines = output.split('\n')
+        for line in lines:
+            if not include_dirs and line.endswith('.h'):
+                include_dirs = os.path.dirname(line.split(':')[1].strip())
+                include_dirs = include_dirs.strip() or None
+            if not library_dirs and line.endswith('.so'):
+                library_dirs = os.path.dirname(line.split(':')[1].strip())
+                library_dirs = library_dirs.strip() or None
+            if include_dirs and library_dirs:
+                break
+    except OSError:
+        print("Failed to find dpkg")
+    return include_dirs, library_dirs
 
 
 def _pkg_config():
     # attempt to find graphviz installation with pkg-config
     # should work with modern versions of graphviz
-    library_path=None
     include_path=None
+    library_path=None
     try:
         output = S.check_output(['pkg-config', '--libs-only-L', 'libcgraph'])
         output = _b2str(output)
         if output:
-            library_path=output.strip()[2:]
+            library_path = output.strip()[2:]
+            library_path = library_path.strip() or None
         output = S.check_output(['pkg-config', '--cflags-only-I', 'libcgraph'])
         output = _b2str(output)
         if output:
-            include_path=output.strip()[2:]
+            include_path = output.strip()[2:]
+            include_path = include_path.strip() or None
     except OSError:
         print("Failed to find pkg-config")
     return include_path, library_path
@@ -65,28 +93,35 @@ def _dotneato_config():
         output = _b2str(output)
         if output:
             include_path, library_path = output.split()
-            library_path = library_path.strip()[2:]
-            include_path = include_path.strip()[2:]
+            library_path = library_path.strip()[2:].strip() or None
+            include_path = include_path.strip()[2:].strip() or None
     except OSError:
         print("Failed to find dotneato-config")
         # fall through and test the other syntax
-    if not include_path and not library_path:
+    if not include_path or not library_path:
         try:
             output = S.check_output(['dotneato-config', '--libs', '--cflags'])
             output = _b2str(output)
             if output:
                 include_path, library_path = output.split('\n',1)
-                library_path = library_path.strip()[2:]
-                include_path = include_path.strip()[2:]
+                library_path = library_path or library_path.strip()[2:].strip() or None
+                include_path = include_path or include_path.strip()[2:].strip() or None
         except OSError:
             print("Failed to find dotneato-config")
 
     return include_path, library_path
 
+def _try_configure(include_dirs, library_dirs, try_function):
+    i, l = try_function()
+    i = include_dirs or i
+    l = library_dirs or l
+    return i, l
+
+
 def get_graphviz_dirs():
     """
     First try to read include_dirs from
-    :return: tuple of lists ([include_dirs], [library_dirs], [define_macros])
+    :return: tuple of lists ([include_dirs], [library_dirs])
     """
 
     # If the setup script couldn't find your graphviz installation you can
@@ -116,13 +151,17 @@ def get_graphviz_dirs():
 
     if sys.platform != "win32":
         # Attempt to find Graphviz installation
-        if library_dirs is None and include_dirs is None:
-            print("Trying pkg-config")
-            include_dirs, library_dirs = _pkg_config()
+        if library_dirs is None or include_dirs is None:
+            print("Trying dpkg")
+            include_dirs, library_dirs = _try_configure(include_dirs, library_dirs, _dpkg_config)
 
-        if library_dirs is None and include_dirs is None:
+        if library_dirs is None or include_dirs is None:
+            print("Trying pkg-config")
+            include_dirs, library_dirs = _try_configure(include_dirs, library_dirs, _pkg_config)
+
+        if library_dirs is None or include_dirs is None:
             print("Trying dotneato-config")
-            include_dirs, library_dirs = _dotneato_config()
+            include_dirs, library_dirs = _try_configure(include_dirs, library_dirs, _dotneato_config)
 
         if library_dirs is None or include_dirs is None:
             print()
@@ -140,8 +179,9 @@ def get_graphviz_dirs():
            http://networkx.lanl.gov/pygraphviz/reference/faq.html
 
         If you think your installation is correct you will need to manually
-        change the include_dirs and library_dirs variables in setup.py to
-        point to the correct locations of your graphviz installation.
+        provide path to graphviz include and library. For example:
+
+        pip install pygraphviz --install-option="--include-path=/usr/include/graphviz" --install-option="--library-path=/usr/lib/graphviz/"
 
         The current setting of library_dirs and include_dirs is:""")
             print("library_dirs=%s"%library_dirs)


### PR DESCRIPTION
- implemented search for graphviz installation using dpkg
- improve handling of empty strings, now if path not found error message is generated
- added unit tests to cover new functionality
- this pull request addresses installation issues for Ubuntu (reported in #72  and #71 )
