### PR TITLE
Convert agraph.py warnings from bytes to strings

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -1337,10 +1337,10 @@ class AGraph(object):
             t.join()
 
         if not data:
-            raise IOError(b"".join(errors))
+            raise IOError(b"".join(errors).decode(self.encoding))
 
         if len(errors) > 0:
-            warnings.warn(b"".join(errors), RuntimeWarning)
+            warnings.warn(b"".join(errors).decode(self.encoding), RuntimeWarning)
 
         return b"".join(data)
 


### PR DESCRIPTION
Warning and error raising behaviour is not correct on Python 3,
where bytes objects cannot be implicitly converted to strings,
and the warnings cause a TypeError crash.

Fixes #94
