### PR TITLE
The warnings module expects a string, not bytes.

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -1340,7 +1340,7 @@ class AGraph(object):
             raise IOError(b"".join(errors))
 
         if len(errors) > 0:
-            warnings.warn(b"".join(errors), RuntimeWarning)
+            warnings.warn(b"".join(errors).decode('utf-8', 'ignore'), RuntimeWarning)
 
         return b"".join(data)
 


### PR DESCRIPTION
Otherwise, it crashes with "TypeError: can't use a string pattern on a
bytes-like object" when the errors list is not empty.