### PR TITLE
Fix build when libcgraph headers are accessible without additional include path

### DIFF
--- a/setup_extra.py
+++ b/setup_extra.py
@@ -58,6 +58,8 @@ def _dpkg_config():
                 break
     except OSError:
         print("Failed to find dpkg")
+    except S.CalledProcessError:
+        print("Could not run dpkg")
     return include_dirs, library_dirs
 
 
@@ -151,19 +153,19 @@ def get_graphviz_dirs():
 
     if sys.platform != "win32":
         # Attempt to find Graphviz installation
-        if library_dirs is None or include_dirs is None:
+        if library_dirs is None and include_dirs is None:
             print("Trying dpkg")
             include_dirs, library_dirs = _try_configure(include_dirs, library_dirs, _dpkg_config)
 
-        if library_dirs is None or include_dirs is None:
+        if library_dirs is None and include_dirs is None:
             print("Trying pkg-config")
             include_dirs, library_dirs = _try_configure(include_dirs, library_dirs, _pkg_config)
 
-        if library_dirs is None or include_dirs is None:
+        if library_dirs is None and include_dirs is None:
             print("Trying dotneato-config")
             include_dirs, library_dirs = _try_configure(include_dirs, library_dirs, _dotneato_config)
 
-        if library_dirs is None or include_dirs is None:
+        if library_dirs is None and include_dirs is None:
             print()
             print("""Your Graphviz installation could not be found.
 


### PR DESCRIPTION
And where dpkg is not avalaible at all.

This is the case on arch linux

Currently installing latest RC version with pip (2 or 3) fails on arch linux:

```
  Running setup.py install for pygraphviz ... error
    Complete output from command /usr/bin/python2 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-SnmpOq/pygraphviz/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-ZtKgcM-record/install-record.txt --single-version-externally-managed --compile:
    running install
    Trying dpkg
    dpkg-query: no path found matching pattern *graphviz*
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-SnmpOq/pygraphviz/setup.py", line 93, in <module>
        tests_require=['nose>=0.10.1', 'doctest-ignore-unicode>=0.1.0', 'mock>=1.3'],
      File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
        dist.run_commands()
      File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
        self.run_command(cmd)
      File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
        cmd_obj.run()
      File "setup_commands.py", line 44, in modified_run
        self.include_path, self.library_path = get_graphviz_dirs()
      File "setup_extra.py", line 156, in get_graphviz_dirs
        include_dirs, library_dirs = _try_configure(include_dirs, library_dirs, _dpkg_config)
      File "setup_extra.py", line 115, in _try_configure
        i, l = try_function()
      File "setup_extra.py", line 47, in _dpkg_config
        output = S.check_output(['dpkg', '-S', 'graphviz'])
      File "/usr/lib/python2.7/subprocess.py", line 574, in check_output
        raise CalledProcessError(retcode, cmd, output=output)
    subprocess.CalledProcessError: Command '['dpkg', '-S', 'graphviz']' returned non-zero exit status 1
    
    ----------------------------------------
  Rolling back uninstall of pygraphviz
```