### PR TITLE
#125: Add test showing erroneous string mutation in AGraph node label…

### DIFF
--- a/pygraphviz/tests/test_html.py
+++ b/pygraphviz/tests/test_html.py
@@ -3,6 +3,60 @@ from nose.tools import *
 import pygraphviz as pgv
 from os import linesep
 
+long_html_string = '''
+<<TABLE BORDER=0>
+  <TR>
+      <TD> meow </TD>
+  </TR>
+  <TR>
+      <TD>
+        <TABLE>
+          <TR>
+          <TD align=left>Count</TD>
+          <TD align=right> 4 </TD>
+          </TR>
+          <TR>
+          <TD align=left>Earliest Run</TD>
+          <TD align=right> yesterday </TD>
+          </TR>
+          <TR>
+          <TD align=left>Latest Run</TD>
+          <TD align=right> tomorrow </TD>
+          </TR>
+          <TR>
+          <TD align=left>Avg Runtime</TD>
+          <TD align=right> 4 seconds </TD>
+          </TR>
+          <TR>
+          <TD align=left>Avg Failure Rate</TD>
+          <TD align=right> 38.1% </TD>
+          </TR>
+        </TABLE>
+      </TD>
+  </TR>
+</TABLE>>
+'''
+
+def test_long_html_string():
+    G = pgv.AGraph(label='<Hello<BR/>Graph>')
+    G.add_node('a', label=long_html_string)
+    s = G.add_subgraph('b', label='<Hello<BR/>Subgraph>')
+    s.add_node('sa', label='<Hello<BR/>Subgraph Node b>')
+    G.add_edge('a','b', label='<Hello<BR/>Edge>')
+    assert_equal.__self__.maxDiff = None
+    assert_equal(G.string().expandtabs(2),
+"""strict graph {{
+  graph [label=<Hello<BR/>Graph>];
+  node [label="\\N"];
+  {{
+    graph [label=<Hello<BR/>Subgraph>];
+    sa     [label=<Hello<BR/>Subgraph Node b>];
+  }}
+  a  [label={0}];
+  a -- b   [label=<Hello<BR/>Edge>];
+}}
+""".format(long_html_string).replace('\n', linesep))
+
 def test_html():
     G = pgv.AGraph(label='<Hello<BR/>Graph>')
     G.add_node('a', label='<Hello<BR/>Node>')

--- a/pygraphviz/tests/test_html.py
+++ b/pygraphviz/tests/test_html.py
@@ -3,8 +3,7 @@ from nose.tools import *
 import pygraphviz as pgv
 from os import linesep
 
-long_html_string = '''
-<<TABLE BORDER=0>
+long_html_string = '''<<TABLE BORDER=0>
   <TR>
       <TD> meow </TD>
   </TR>
@@ -34,8 +33,7 @@ long_html_string = '''
         </TABLE>
       </TD>
   </TR>
-</TABLE>>
-'''
+</TABLE>>'''
 
 def test_long_html_string():
     G = pgv.AGraph(label='<Hello<BR/>Graph>')


### PR DESCRIPTION
Initially all this PR does is add a test case demonstrating the string mutation that leads to a borked html formatted label. The test case fails as described in #125.

I'd be happy to hack at this if someone could give me a hint or two as to where this string mutation might be occurring.