### PR TITLE
Fix deprecation warnings

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 import threading
 import warnings
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 from . import graphviz as gv
 
@@ -141,7 +141,7 @@ class AGraph(object):
             elif hasattr(thing, 'own'):  # a Swig pointer - graph handle
                 handle = thing
             elif is_string_like(thing):
-                pattern = re.compile('(strict)?\s*(graph|digraph).*{.*}\s*',
+                pattern = re.compile(r'(strict)?\s*(graph|digraph).*{.*}\s*',
                                      re.DOTALL)
                 if pattern.match(thing):
                     string = thing  # this is a dot format graph in a string

--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -17,7 +17,12 @@ import subprocess
 import sys
 import threading
 import warnings
-from collections.abc import MutableMapping
+try:
+    # Python 3
+    from collections.abc import MutableMapping
+except ImportError:
+    # Python 2.7
+    from collections import MutableMapping
 
 from . import graphviz as gv
 


### PR DESCRIPTION
I noticed that I was getting the following deprecation warnings when running pygraphviz under python 3.7.2:

```
pygraphviz/agraph.py:20: DeprecationWarning: Using or importing the ABCs from
'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will
stop working
```

```
pygraphviz/agraph.py:144: DeprecationWarning: invalid escape sequence \s
```

This PR fixes those warnings.