### PR TITLE
doc: use add_object_type() instead of deprecated add_description_unit()

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -190,7 +190,7 @@ def parse_event(env, sig, signode):
 def setup(app):
     from sphinx.ext.autodoc import cut_lines
     app.connect('autodoc-process-docstring', cut_lines(4, what=['module']))
-    app.add_description_unit('directive', 'dir', 'pair: %s; directive', parse_directive)
-    app.add_description_unit('role', 'role', 'pair: %s; role', parse_role)
-    app.add_description_unit('confval', 'confval', 'pair: %s; configuration value')
-    app.add_description_unit('event', 'event', 'pair: %s; event', parse_event)
+    app.add_object_type('directive', 'dir', 'pair: %s; directive', parse_directive)
+    app.add_object_type('role', 'role', 'pair: %s; role', parse_role)
+    app.add_object_type('confval', 'confval', 'pair: %s; configuration value')
+    app.add_object_type('event', 'event', 'pair: %s; event', parse_event)


### PR DESCRIPTION
This is necessary to build the docs with sphinx-2.x.

sphinx-2.0 removed the deprecated function.
See https://bugs.python.org/issue34967 for similar changes in cpython.