### PR TITLE
Add additional include path

### DIFF
--- a/setup_extra.py
+++ b/setup_extra.py
@@ -78,7 +78,10 @@ def _pkg_config():
         output = _b2str(output)
         if output:
             include_path = output.strip()[2:]
-            include_path = include_path.strip() or None
+            include_path = include_path.strip()
+            # This line below adds an extra include path for certain cases where pkg-config 
+            # returns the full path to the cgraph.h directory (e.g. with Homebrew and MacPorts.
+            include_path = include_path + ":" + "/".join(include_path.split("/")[:-1]) or None
     except OSError:
         print("Failed to find pkg-config")
     return include_path, library_path


### PR DESCRIPTION
Adding an additional include path to find `graphviz/cgraph.h`. For example, running 

```
pkg-config --cflags-only-I libcgraph
```

with MacPorts returns

```
-I/opt/local/include/graphviz
```

(and similarly for Homebrew, except for `usr` instead of `opt`)