### PR TITLE
Fix DeprecationWarning: invalid escape sequence \d

### DIFF
--- a/pygraphviz/release.py
+++ b/pygraphviz/release.py
@@ -53,8 +53,8 @@ def get_svn_revision():
         entries = open(entries_path, 'r').read()
         # Versions >= 7 of the entries file are flat text.  The first line is
         # the version number. The next set of digits after 'dir' is the revision.
-        if re.match('(\d+)', entries):
-            rev_match = re.search('\d+\s+dir\s+(\d+)', entries)
+        if re.match(r'(\d+)', entries):
+            rev_match = re.search(r'\d+\s+dir\s+(\d+)', entries)
             if rev_match:
                 rev = rev_match.groups()[0]
     if rev:


### PR DESCRIPTION
This deprecation warning started to appear in Python 3.6