### PR TITLE
AGraph Graphviz handle close mechanism

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -273,7 +273,7 @@ class AGraph(object):
     #        self.add_edge(u,v)
 
     def __del__(self):
-        self.close()
+        self._close_handle()
 
     def get_name(self):
         name = gv.agnameof(self.handle)
@@ -987,6 +987,7 @@ class AGraph(object):
         directed = self.directed
         self._close_handle()
         self.handle = gv.agraphnew(name, strict, directed)
+        self._owns_handle = True
         self._update_handle_references()
 
     def close(self):
@@ -1246,6 +1247,7 @@ class AGraph(object):
             except ValueError:
                 raise DotError("Invalid Input")
             else:
+                self._owns_handle = True
                 self._update_handle_references()
         except IOError:
             print("IO error reading file")

--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -124,6 +124,7 @@ class AGraph(object):
                  filename=None, data=None, string=None, handle=None,
                  name='', strict=True, directed=False, **attr):
         self.handle = None  # assign first in case the __init__ bombs
+        self._owns_handle = True
         # initialization can take no arguments (gives empty graph) or
         # a file name
         # a string of graphviz dot language
@@ -158,6 +159,7 @@ class AGraph(object):
         if handle is not None:
             # if handle was specified, reference it
             self.handle = handle
+            self._owns_handle = False
         elif filename is not None:
             # load new graph from file (creates self.handle)
             self.read(filename)
@@ -990,12 +992,18 @@ class AGraph(object):
     def close(self):
         self._close_handle()
 
+
     def _close_handle(self):
         # may be useful to clean up graphviz data
         # this should completely remove all of the existing graphviz data
-        if self.handle is not None:
-            gv.agclose(self.handle)
+        if self._owns_handle:
+            if self.handle is not None:
+                gv.agclose(self.handle)
+                self.handle = None
+            self._owns_handle = False
+        else:
             self.handle = None
+
 
     def copy(self):
         """Return a copy of the graph."""

--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -224,7 +224,7 @@ class AGraph(object):
         return self
 
     def __exit__(self, ext_type, exc_value, traceback):
-        self.close()
+        pass
 
     if _PY2:
         def __unicode__(self):
@@ -251,7 +251,6 @@ class AGraph(object):
         # hash the string representation for id
         return hash(self.string())
 
-
     def __iter__(self):
         # provide "for n in G"
         return self.nodes_iter()
@@ -270,6 +269,9 @@ class AGraph(object):
     # not implemented, but could be...
     #    def __setitem__(self,u,v):
     #        self.add_edge(u,v)
+
+    def __del__(self):
+        self.close()
 
     def get_name(self):
         name = gv.agnameof(self.handle)
@@ -981,14 +983,19 @@ class AGraph(object):
         name = gv.agnameof(self.handle)
         strict = self.strict
         directed = self.directed
-        gv.agclose(self.handle)
+        self._close_handle()
         self.handle = gv.agraphnew(name, strict, directed)
         self._update_handle_references()
 
     def close(self):
+        self._close_handle()
+
+    def _close_handle(self):
         # may be useful to clean up graphviz data
         # this should completely remove all of the existing graphviz data
-        gv.agclose(self.handle)
+        if self.handle is not None:
+            gv.agclose(self.handle)
+            self.handle = None
 
     def copy(self):
         """Return a copy of the graph."""
@@ -1225,8 +1232,7 @@ class AGraph(object):
         """
         fh = self._get_fh(path)
         try:
-            if self.handle is not None:
-                gv.agclose(self.handle)
+            self._close_handle()
             try:
                 self.handle = gv.agread(fh, None)
             except ValueError:

--- a/pygraphviz/tests/test_close.py
+++ b/pygraphviz/tests/test_close.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from nose.tools import *
+import pygraphviz as pgv
+
+
+def test_context_manager():
+    with pgv.AGraph() as ag:
+        ag0 = ag
+    assert_not_equal(ag0.handle, None)
+
+
+def test_double_close():
+    ag = pgv.AGraph()
+    ag.close()
+    assert_equal(ag.handle, None)
+    ag.close()


### PR DESCRIPTION
Browse code while investigating [\[SO\]: Pygraphviz crashes after drawing 170 graphs (@CristiFati's answer)](https://stackoverflow.com/questions/60876623/pygraphviz-crashes-after-drawing-170-graphs/61050313#61050313).

Although closing the handle doesn't have any visible effect, it's better to happen automatically when an object is destroyed (instead at `with` end). Also calling *close* twice (as it's public) would no longer crash.

As a side note, many tests failed when I ran them (original code).

**Recap** - this patch fixes:
- The double *close* crash
- Handle close performed at object destruction instead of the context manager's
- Better organize the code
- The 3<sup>rd</sup> commit excludes inherited handles from being closed (as it's each entity's responsibility to release resources that it allocated).
