### PR TITLE
agraph: Allow _get_fh to accept a Path-like object

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -152,6 +152,8 @@ class AGraph(object):
                     string = thing  # this is a dot format graph in a string
                 else:
                     filename = thing  # assume this is a file name
+            elif hasattr(thing, 'open'):
+                filename = thing  # assume this is a file name (in a path obj)
             else:
                 raise TypeError('Unrecognized input %s' % thing)
 

--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -1534,7 +1534,7 @@ class AGraph(object):
     def _get_fh(self, path, mode='r'):
         """ Return a file handle for given path.
 
-        Path can be a string or a file handle.
+        Path can be a string, pathlib.Path, or a file handle.
         Attempt to uncompress/compress files ending in '.gz' and '.bz2'.
         """
         import os
@@ -1553,8 +1553,10 @@ class AGraph(object):
         elif hasattr(path, 'write'):
             # Note, mode of file handle is unchanged.
             fh = path
+        elif hasattr(path, 'open'):
+            fh = path.open(mode=mode)
         else:
-            raise TypeError('path must be a string or file handle.')
+            raise TypeError('path must be a string, path, or file handle.')
         return fh
 
     def _which(self, name):

--- a/pygraphviz/tests/test_readwrite.py
+++ b/pygraphviz/tests/test_readwrite.py
@@ -5,12 +5,29 @@ from nose.tools import assert_false
 import pygraphviz as pgv
 import os
 import tempfile
+import pathlib
 
 def test_readwrite():
     A = pgv.AGraph(name='test graph')
     A.add_path([1,2,3,4,5,6,7,8,9,10])
     the_file = tempfile.NamedTemporaryFile(delete=False)
     fname = the_file.name
+    # Make sure it can be opened for writing again on Win32
+    the_file.close()
+    # Pass a string to trigger the code paths that close the newly created file handle
+    A.write(fname)
+    B = pgv.AGraph(fname)
+    assert_equal(A, B)
+    assert_true(B == A)
+    assert_false(B is A)
+    os.unlink(fname)
+
+
+def test_readwrite_pathobj():
+    A = pgv.AGraph(name='test graph')
+    A.add_path([1,2,3,4,5,6,7,8,9,10])
+    the_file = tempfile.NamedTemporaryFile(delete=False)
+    fname = pathlib.Path(the_file.name)
     # Make sure it can be opened for writing again on Win32
     the_file.close()
     # Pass a string to trigger the code paths that close the newly created file handle


### PR DESCRIPTION
Hi there! Thanks a ton for this Python binding.

This PR adds support for passing Path-like objects through much of the PyGraphviz API.

`pathlib.Path` (Python 3.4+) and other `Path`-like objects respond to `open`, so this PR tests for them based on that attribute.

Please let me know if there's anything else I can do!