### PR TITLE
Update related.rst - Typo in header of "related packages" doc page

### DIFF
--- a/doc/source/reference/related.rst
+++ b/doc/source/reference/related.rst
@@ -1,4 +1,4 @@
-Related Pacakges
+Related Packages
 ----------------
 
    - Python bindings distributed with Graphviz (graphviz-python):  http://www.graphviz.org/


### PR DESCRIPTION
Typo in header of "Related Packages" documentation page.