### PR TITLE
Remove stale mock dependency

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -104,7 +104,7 @@ For Red Hat Enterprise Linux 7, the requirements are::
    
    sudo yum groups install -y "Development Tools"
    sudo yum install -y python-devel graphviz-devel
-   sudo python -m pip install nose doctest-ignore-unicode mock
+   sudo python -m pip install nose doctest-ignore-unicode
 
 
 GraphViz

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,3 @@
 coveralls==1.3.0
 nose==1.3.7
 doctest-ignore-unicode==0.1.2
-mock==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -87,5 +87,5 @@ if __name__ == "__main__":
         include_package_data = True,
         test_suite='nose.collector',
         python_requires='>=3.6',
-        tests_require=['nose>=1.3.7', 'doctest-ignore-unicode>=0.1.2', 'mock>=2.0.0'],
+        tests_require=['nose>=1.3.7', 'doctest-ignore-unicode>=0.1.2'],
     )


### PR DESCRIPTION
Since pygraphviz no longer supports Python 2 and entirely relies
on built-in unittest.mock module, the dependency on mock is no longer
necessary.