### PR TITLE
Update __eq__() and copy() to use the stored nodes and edges

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -265,8 +265,11 @@ class AGraph:
         return True
 
     def __hash__(self):
-        # hash the string representation for id
-        return hash(self.string())
+        # include nodes and edges in hash
+        # Could do attributes too, but hash should be fast
+        return hash((tuple(sorted(self.nodes_iter())),
+                     tuple(sorted(self.edges_iter())),
+                     ))
 
     def __iter__(self):
         # provide "for n in G"

--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -241,9 +241,28 @@ class AGraph:
         return f"<AGraph {name} {self.handle}>"
 
     def __eq__(self, other):
-        # two graphs are equal if they have exact same string representation
-        # this is not graph isomorphism
-        return self.string() == other.string()
+        # two graphs are equal if they have exact same nodes and edges
+        # and attributes.  This is not graph isomorphism.
+        if sorted(self.nodes()) != sorted(other.nodes()):
+            return False
+        if sorted(self.edges()) != sorted(other.edges()):
+            return False
+        # check attributes
+        if tuple(dict(n.attr) for n in sorted(self.nodes_iter())) != tuple(dict(n.attr) for n in sorted(other.nodes_iter())):
+            return False
+        if tuple(dict(e.attr) for e in sorted(self.edges_iter())) != tuple(dict(e.attr) for e in sorted(other.edges_iter())):
+            return False
+        # We could check the default attributes too.
+        # But they aren't reflected in the attibutes until node is added.
+        # That leads to order dependent additions for equality...
+        # Code would be:
+        # check default attributes
+        ##if {n: nv for n, nv in self.node_attr.items() if nv != ''} != \
+        ##   {n: nv for n, nv in other.node_attr.items() if nv != ''}:
+        ##    return False
+
+        # All checks pass.  They are equal
+        return True
 
     def __hash__(self):
         # hash the string representation for id
@@ -991,20 +1010,24 @@ class AGraph:
             self.handle = None
 
     def copy(self):
-        """Return a copy of the graph."""
-        from tempfile import TemporaryFile
-
-        fh = TemporaryFile()
-        # Cover TemporaryFile wart: on 'nt' we need the file member
-        if hasattr(fh, "file"):
-            fhandle = fh.file
-        else:
-            fhandle = fh
-
-        self.write(fhandle)
-        fh.seek(0)
-
-        return self.__class__(filename=fhandle)
+        """Return a copy of the graph.
+        
+        Notes
+        =====
+        Versions <=1.6 made a copy by writing and the reading a dot string.
+        This version loads a new graph with nodes, edges and attributes.
+        """
+        G = self.__class__()
+        for node in self.nodes():
+            G.add_node(node)
+            G.get_node(node).attr.update(self.get_node(node).attr)
+        for edge in self.edges():
+            G.add_edge(*edge)
+            G.get_edge(*edge).attr.update(self.get_edge(*edge).attr)
+        G.graph_attr.update(self.graph_attr)
+        G.node_attr.update(self.node_attr)
+        G.edge_attr.update(self.edge_attr)
+        return G
 
     def add_path(self, nlist):
         """Add the path of nodes given in nlist."""

--- a/pygraphviz/tests/test_graph.py
+++ b/pygraphviz/tests/test_graph.py
@@ -1,6 +1,6 @@
-import pygraphviz as pgv
 import pytest
 import unittest
+import pygraphviz as pgv
 
 
 def stringify(agraph):
@@ -63,6 +63,69 @@ class TestGraph(unittest.TestCase):
         H = pgv.AGraph()
         assert H == A
         assert H is not A
+
+        assert self.P3 == self.P3
+
+        A = pgv.AGraph()
+        A.add_path([1, 2, 3])
+        assert A.nodes() == self.P3.nodes()
+        assert A.edges() == self.P3.edges()
+        assert stringify(A) == stringify(self.P3)
+        assert A == self.P3
+
+    def test_not_equal(self):
+        A = pgv.AGraph()
+        A.add_path([1, 2, 3])
+        B = self.P3
+        assert A == B
+
+        A.add_node(4)
+        assert A != B
+        A.remove_node(4)
+        assert A == B
+        A.add_edge(3, 1)
+        assert A != B
+        A.remove_edge(3, 1)
+        assert A == B
+
+        A.add_node(4, hi=9)
+        assert A != B
+        A.remove_node(4)
+        assert A == B
+        A.add_edge(3, 1, hi=9)
+        assert A != B
+        A.remove_edge(3, 1)
+        assert A == B
+
+        # Note: default attributes dont affect equality
+        A.node_attr['low'] = 3
+        assert A == B
+        B.node_attr['low'] = 3
+        assert A == B
+        A.edge_attr['low'] = 4
+        assert A == B
+        B.edge_attr['low'] = 4
+        assert A == B
+        A.graph_attr.update({'low': 5})
+        assert A == B
+        # print(sorted(A.nodes()), sorted(B.nodes()))
+        # print(sorted(A.edges()), sorted(B.edges()))
+        # print(tuple(dict(n.attr) for n in sorted(A.nodes())))
+        # print(tuple(dict(n.attr) for n in sorted(B.nodes())))
+        # print(tuple(dict(e.attr) for e in sorted(A.edges())))
+        # print(tuple(dict(e.attr) for e in sorted(B.edges())))
+        # print(dict(A.node_attr), dict(B.node_attr))
+        # print(dict(A.edge_attr), dict(B.edge_attr))
+        # print(dict(A.graph_attr), dict(B.graph_attr))
+
+    def test_hash(self):
+        A = pgv.AGraph()
+        A.add_path([1, 2, 3])
+        assert hash(A) == hash(self.P3)
+        B = A.copy()
+        assert hash(A) == hash(B)
+        B.add_node(4)
+        assert hash(A) != hash(B)
 
     def test_iter(self):
         assert sorted(list(self.P3.__iter__())) == ["1", "2", "3"]
@@ -224,9 +287,10 @@ class TestGraph(unittest.TestCase):
         A = self.P3.copy()
         assert A.nodes() == ["1", "2", "3"]
         assert A.edges() == [("1", "2"), ("2", "3")]
-        assert A == self.P3
         assert A is not self.P3
         assert self.P3 is self.P3
+        assert stringify(A) == stringify(self.P3)
+        assert A == self.P3
 
     def test_add_path(self):
         A = pgv.AGraph()


### PR DESCRIPTION
The equals function was based on dot string format which changes (adds and remove spaces, etc) by operating system, version of graphviz, etc. That makes testing quite hard. It can also lead to strange results where changing a graph and then changing it back leads to not equal. 

This new ```__eq__``` and ```copy``` use the nodes and attributes in the object to check for equality and to copy.
The state of the object is no longer designated by the dot file produced.