### PR TITLE
Modify graphviz_wrap.c to make compilation work on macOS and Linux

### DIFF
--- a/pygraphviz/graphviz_wrap.c
+++ b/pygraphviz/graphviz_wrap.c
@@ -2673,7 +2673,7 @@ static swig_module_info swig_module = {swig_types, 8, 0, 0, 0, 0};
 #define SWIG_as_voidptrptr(a) ((void)SWIG_as_voidptr(*a),(void**)(a)) 
 
 
-#include "graphviz/cgraph.h"
+#include "cgraph.h"
 
 
 static PyObject *PyIOBase_TypeObj;

--- a/setup_extra.py
+++ b/setup_extra.py
@@ -72,9 +72,6 @@ def _pkg_config():
         if output:
             include_path = output.strip()[2:]
             include_path = include_path.strip()
-            # This line below adds an extra include path for certain cases where pkg-config 
-            # returns the full path to the cgraph.h directory (e.g. with Homebrew and MacPorts.
-            include_path = include_path + ":" + "/".join(include_path.split("/")[:-1]) or None
     except OSError:
         print("Failed to find pkg-config")
     return include_path, library_path


### PR DESCRIPTION
This PR changes the include directive for `cgraph.h` in `pygraphviz/graphviz_wrap.c` to make `pip install pygraphviz` able to run successfully on macOS machines that can use `pkg-config` to find the include path for `cgraph.h` (this is the case with the MacPorts package manager, but not the Homebrew package manager - apparently Homebrew's version of graphviz does not include pkg-config support, so it needs the workaround in PR #253).

This PR supersedes PR #200, and has been tested with MacOS Catalina and Ubuntu 18.04. 

The previous version of the include directive - `#include "graphviz/cgraph.h"` worked by accident on Ubuntu, since `gcc` automatically uses `/usr/include` as one of the include paths, and installing Graphviz using `apt-get` installs the cgraph.h header to `/usr/include/graphviz/cgraph.h`.