### PR TITLE
Test on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,3 +80,50 @@ jobs:
 
     - name: Test pygraphviz
       run: pytest --pyargs pygraphviz
+
+
+  windows:
+
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+
+    - name: Checkout pygraphviz
+      uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Download graphviz source
+      run: Invoke-WebRequest -Uri "https://www2.graphviz.org/Packages/stable/windows/10/cmake/Release/x64/graphviz-install-2.44.1-win64.exe" -OutFile "C:\Temp\graphviz-install-2.44.1-win64.exe"
+
+    - name: Install exe
+      run: Start-Process -Wait -FilePath "C:\Temp\graphviz-install-2.44.1-win64.exe" -ArgumentList '/S' -PassThru
+
+    - name: Install packages
+      run: |
+        $PATH = [Environment]::GetEnvironmentVariable("PATH")
+        $graphviz_path = "C:\Program Files\Graphviz 2.44.1\bin"
+        [Environment]::SetEnvironmentVariable("PATH", "$graphviz_path;$PATH")
+        dot -c
+        dot -v
+        pip install --upgrade pip wheel setuptools --user
+        pip install -r requirements/doc.txt --user
+        pip install -r requirements/test.txt --user
+        python setup.py build_ext --include-dirs="C:\Program Files\Graphviz 2.44.1\include" --library-dirs="C:\Program Files\Graphviz 2.44.1\lib"
+        python setup.py install --user
+        pip list
+
+    - name: Test pygraphviz
+      run: |
+        $PATH = [Environment]::GetEnvironmentVariable("PATH")
+        $graphviz_path = "C:\Program Files\Graphviz 2.44.1\bin"
+        [Environment]::SetEnvironmentVariable("PATH", "$graphviz_path;$PATH")
+        [Environment]::SetEnvironmentVariable("PY_IGNORE_IMPORTMISMATCH", 1)
+        pytest --pyargs pygraphviz

--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -1408,7 +1408,9 @@ class AGraph:
 
         >>> A = AGraph()
         >>> A_unflattened = A.unflatten('-f -l 3')
-        >>> A.unflatten('-f -l 1').layout()
+        >>> # FIXME: Windows 'CMake' installer does not install neato, gvpr, fdp and others
+        >>> # https://gitlab.com/graphviz/graphviz/-/issues/1753
+        >>> A.unflatten('-f -l 1').layout() # doctest: +SKIP
 
         Use keyword args to add additional arguments to graphviz programs.
         """
@@ -1423,7 +1425,9 @@ class AGraph:
         will use specified graphviz layout method.
 
         >>> A=AGraph()
-        >>> A.layout() # uses neato
+        >>> # FIXME: Windows 'CMake' installer does not install neato, gvpr, fdp and others
+        >>> # https://gitlab.com/graphviz/graphviz/-/issues/1753
+        >>> A.layout() # doctest: +SKIP
         >>> A.layout(prog='dot')
 
         Use keyword args to add additional arguments to graphviz programs.
@@ -1500,16 +1504,22 @@ class AGraph:
         will use specified graphviz layout method.
 
         >>> G = AGraph()
-        >>> G.layout()
+        >>> # FIXME: Windows 'CMake' installer does not install neato, gvpr, fdp and others
+        >>> # https://gitlab.com/graphviz/graphviz/-/issues/1753
+        >>> G.layout() # doctest: +SKIP
 
         # use current node positions, output ps in 'file.ps'
-        >>> G.draw('file.ps')
+        >>> # FIXME: Windows 'CMake' installer does not install neato, gvpr, fdp and others
+        >>> # https://gitlab.com/graphviz/graphviz/-/issues/1753
+        >>> G.draw('file.ps') # doctest: +SKIP
 
         # use dot to position, output png in 'file'
         >>> G.draw('file', format='png',prog='dot')
 
         # use keyword 'args' to pass additional arguments to graphviz
-        >>> G.draw('test.ps',prog='twopi',args='-Gepsilon=1')
+        >>> # FIXME: Windows 'CMake' installer does not install neato, gvpr, fdp and others
+        >>> # https://gitlab.com/graphviz/graphviz/-/issues/1753
+        >>> G.draw('test.ps',prog='twopi',args='-Gepsilon=1')  # doctest: +SKIP
 
         The layout might take a long time on large graphs.
 

--- a/pygraphviz/tests/test_layout.py
+++ b/pygraphviz/tests/test_layout.py
@@ -1,6 +1,11 @@
+import pytest
+import sys
+
 import pygraphviz as pgv
 
-
+# FIXME: Windows 'CMake' installer does not install neato, gvpr, fdp and others
+# https://gitlab.com/graphviz/graphviz/-/issues/1753
+@pytest.mark.xfail(sys.platform == "win32", reason="does not run on windows")
 def test_layout():
     A = pgv.AGraph(name="test graph")
     A.add_path([1, 2, 3, 4])


### PR DESCRIPTION
This adds CI testing for Windows using the official Graphviz 64bit cmake installer.  There is also an official MSBuild build, but it doesn't include header files.  We should also look into the chocolatey packages (I am not sure if they include header files):
https://chocolatey.org/packages/Graphviz/2.44.1

There are a couple of issues with the official Graphviz 64bit cmake installer / GH action:

1. The cmake installer is new and does not install everything (e.g., neato, gvpr, and fdp are missing).  This is a known issue and it is being worked on.  You can find more information here:
https://gitlab.com/graphviz/graphviz/-/issues/1753

2. I set the environment variable ``PY_IGNORE_IMPORTMISMATCH=1`` to avoid getting this ImportMismatchError:
```
E   _pytest.pathlib.ImportPathMismatchError: ('pygraphviz._graphviz', 'C:\\Users\\runneradmin\\AppData\\Roaming\\Python\\Python37\\site-packages\\pygraphviz-1.7.dev0-py3.7-win-amd64.egg\\pygraphviz\\_graphviz.cp37-win_amd64.pyd', WindowsPath('C:/Users/runneradmin/AppData/Roaming/Python/Python37/site-packages/pygraphviz-1.7.dev0-py3.7-win-amd64.egg/pygraphviz/_graphviz.py'))
```

3. This doesn't work on Python 3.8 and 3.9 for some reason.  It doesn't work on PyPy-3.7 because pytest isn't found in the path (that should be easy to fix, but I will do it in a separate PR).

I believe we should merge this and continue to improve it later.
I had never seen this error and it looked to me like the problem due to which slash is used in the path.  We should investigate and fix this, but ignoring the mismatch allows us to run the tests.