### PR TITLE
Fix equals dunder to consider attributes.

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -240,8 +240,8 @@ class AGraph:
         other_all_nodes_attr = {n: n.attr.to_dict() for n in sorted(other.nodes_iter())}
         if self_all_nodes_attr != other_all_nodes_attr:
             return False
-        self_all_edges_attr = {n: n.attr.to_dict() for n in sorted(self.edges_iter())}
-        other_all_edges_attr = {n: n.attr.to_dict() for n in sorted(other.edges_iter())}
+        self_all_edges_attr = {e: e.attr.to_dict() for e in sorted(self.edges_iter())}
+        other_all_edges_attr = {e: e.attr.to_dict() for e in sorted(other.edges_iter())}
         if self_all_edges_attr != other_all_edges_attr:
             return False
 

--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -252,7 +252,10 @@ class AGraph:
         # include nodes and edges in hash
         # Could do attributes too, but hash should be fast
         return hash(
-            (tuple(sorted(self.nodes_iter())), tuple(sorted(self.edges_iter())),)
+            (
+                tuple(sorted(self.nodes_iter())),
+                tuple(sorted(self.edges_iter())),
+            )
         )
 
     def __iter__(self):

--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -208,7 +208,7 @@ class AGraph:
             del attr["charset"]
 
         # assign any attributes specified through keywords
-        self.graph_attr = Attribute(self.handle, 0)  # default graph attributes
+        self.graph_attr = Attribute(self.handle, 0)  # graph attributes
         self.graph_attr.update(attr)  # apply attributes passed to init
         self.node_attr = Attribute(self.handle, 1)  # default node attributes
         self.edge_attr = Attribute(self.handle, 2)  # default edge attribtes
@@ -236,22 +236,14 @@ class AGraph:
         if sorted(self.edges()) != sorted(other.edges()):
             return False
         # check attributes
-        self_node_attr = tuple(dict(n.attr) for n in sorted(self.nodes_iter()))
-        other_node_attr = tuple(dict(n.attr) for n in sorted(other.nodes_iter()))
-        if self_node_attr != other_node_attr:
+        self_all_nodes_attr = {n: n.attr.to_dict() for n in sorted(self.nodes_iter())}
+        other_all_nodes_attr = {n: n.attr.to_dict() for n in sorted(other.nodes_iter())}
+        if self_all_nodes_attr != other_all_nodes_attr:
             return False
-        self_edge_attr = tuple(dict(e.attr) for e in sorted(self.edges_iter()))
-        other_edge_attr = tuple(dict(e.attr) for e in sorted(other.edges_iter()))
-        if self_edge_attr != other_edge_attr:
+        self_all_edges_attr = {n: n.attr.to_dict() for n in sorted(self.edges_iter())}
+        other_all_edges_attr = {n: n.attr.to_dict() for n in sorted(other.edges_iter())}
+        if self_all_edges_attr != other_all_edges_attr:
             return False
-        # We could check the default attributes too.
-        # But they aren't reflected in the attibutes until node is added.
-        # That leads to order dependent additions for equality...
-        # Code would be:
-        # check default attributes
-        ##if {n: nv for n, nv in self.node_attr.items() if nv != ''} != \
-        ##   {n: nv for n, nv in other.node_attr.items() if nv != ''}:
-        ##    return False
 
         # All checks pass.  They are equal
         return True
@@ -260,10 +252,7 @@ class AGraph:
         # include nodes and edges in hash
         # Could do attributes too, but hash should be fast
         return hash(
-            (
-                tuple(sorted(self.nodes_iter())),
-                tuple(sorted(self.edges_iter())),
-            )
+            (tuple(sorted(self.nodes_iter())), tuple(sorted(self.edges_iter())),)
         )
 
     def __iter__(self):
@@ -2113,3 +2102,16 @@ class ItemAttribute(Attribute):
                 continue
             except StopIteration:  # gv.agnxtattr is done, as are we
                 return
+
+    def to_dict(self):
+        ah = None
+        attrdict = {}
+        while 1:
+            try:
+                ah = gv.agnxtattr(self.ghandle, self.type, ah)
+            except StopIteration:  # gv.agnxtattr is done, as are we
+                break
+            key = gv.agattrname(ah).decode(self.encoding)
+            value = gv.agxget(self.handle, ah).decode(self.encoding)
+            attrdict[key] = value
+        return attrdict

--- a/pygraphviz/tests/test_graph.py
+++ b/pygraphviz/tests/test_graph.py
@@ -89,21 +89,33 @@ class TestGraph(unittest.TestCase):
         A.add_node(4, hi=9)
         assert A != B
         A.remove_node(4)
+        assert A != B  # attribute 'hi' exists for every node.
+        B.node_attr["hi"] = ""
         assert A == B
         A.add_edge(3, 1, hi=9)
         assert A != B
         A.remove_edge(3, 1)
+        assert A != B
+        B.edge_attr["hi"] = ""
         assert A == B
 
-        # Note: default attributes dont affect equality
+        # Note: adding node attr gives every node that attribute but empty.
+        # Default values are only assigned to nodes added after default is set.
         A.node_attr["low"] = 3
-        assert A == B
+        assert A != B
         B.node_attr["low"] = 3
         assert A == B
-        A.edge_attr["low"] = 4
+        B.node_attr["low"] = 4
+        assert A == B
+
+        A.edge_attr["low"] = 3
+        assert A != B
+        B.edge_attr["low"] = 3
         assert A == B
         B.edge_attr["low"] = 4
         assert A == B
+
+        # graph_attr are not default values -- they are attribute values.
         A.graph_attr.update({"low": 5})
         assert A == B
         # print(sorted(A.nodes()), sorted(B.nodes()))
@@ -448,7 +460,11 @@ def test_agraph_equality_node_attrs():
     # Change attribute of a single node in B
     B.get_node(1).attr["color"] = "blue"
     # Graphs are no longer considered equal
-    assert not A == B
+    assert A != B
+    # See #284  A and C should be different
+    C = pgv.AGraph()
+    A.add_nodes_from(nodes)
+    assert A != C
 
 
 def test_agraph_equality_edge_attrs():
@@ -459,7 +475,11 @@ def test_agraph_equality_edge_attrs():
     assert A == B
     # Change edge attribute
     B.get_edge(0, 1).attr["weight"] = 2.0
-    assert not A == B
+    assert A != B
+    # See #284  A and C should be different
+    C = pgv.AGraph()
+    A.add_edge(0, 1)
+    assert A != C
 
 
 def test_agraph_has_edge_single_input_parsing():


### PR DESCRIPTION
To include default attribute values in equals dunder, I added a new method `ItemAttribute.to_dict()` that differs from `ItemAttribute.iteritems()`. The `iteritems` ignores attributes if the value equals the default. The `to_dict` includes the attribute whether it has the default value or not.

Fixes #284 