### PR TITLE
CI: fix failing fedora jobs.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,9 @@ jobs:
 
     steps:
 
+    - name: update dnf
+      run: sudo dnf upgrade
+
     - name: Checkout pygraphviz
       uses: actions/checkout@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
 
     - name: update dnf
-      run: sudo dnf upgrade
+      run: sudo dnf upgrade -y
 
     - name: Checkout pygraphviz
       uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,20 +58,17 @@ jobs:
 
     steps:
 
-    - name: update dnf
-      run: sudo dnf upgrade -y
-
     - name: Checkout pygraphviz
       uses: actions/checkout@v2
 
     - name: Install graphviz
-      run: sudo dnf install -y graphviz graphviz-devel
+      run: sudo dnf install --nogpg -y graphviz graphviz-devel
 
     - name: Install Python developer tools
-      run: sudo dnf install -y python3-devel
+      run: sudo dnf install --nogpg -y python3-devel
 
     - name: Install gcc
-      run: sudo dnf install -y gcc
+      run: sudo dnf install -y --nogpg gcc
 
     - name: Install packages
       run: |


### PR DESCRIPTION
The CI jobs for testing on fedora are failing due to failed checks of gpg-keys in the installation process. The failed key checks aren't specific to graphviz, so the failures seem unrelated. This PR works around this issue by skipping the key checks with the `--nogpg` flag. I'm not too familiar with `dnf`, so there may be a better way to do this.