### PR TITLE
Fixed installation readme path in homepage readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Install
 -------
 
 PyGraphviz requires Graphviz.
-Please see `INSTALL.rst` for details.
+Please see `INSTALL.txt` for details.
 
 License
 -------


### PR DESCRIPTION
The installation details are not found in INSTALL.rst (because that file does not exist). Changed reference to INSTALL.txt.