### PR TITLE
Add IPython rich display hook to AGraph class

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -230,6 +230,9 @@ class AGraph:
             return f"<AGraph {self.handle}>"
         return f"<AGraph {name} {self.handle}>"
 
+    def _repr_svg_(self):
+        return self.draw(format='svg').decode(self.encoding)
+
     def __eq__(self, other):
         # two graphs are equal if they have exact same nodes and edges
         # and attributes.  This is not graph isomorphism.

--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -230,8 +230,15 @@ class AGraph:
             return f"<AGraph {self.handle}>"
         return f"<AGraph {name} {self.handle}>"
 
-    def _repr_svg_(self):
-        return self.draw(format='svg').decode(self.encoding)
+    def _svg_repr(self):
+        return self.draw(format="svg").decode(self.encoding)
+
+    def _repr_mimebundle_(self, include=None, exclude=None):
+        if self.has_layout:
+            repr_dict = {"image/svg+xml": self._svg_repr()}
+        else:
+            repr_dict = {"text/plain": self.__repr__()}
+        return repr_dict
 
     def __eq__(self, other):
         # two graphs are equal if they have exact same nodes and edges

--- a/pygraphviz/tests/test_repr_mimebundle.py
+++ b/pygraphviz/tests/test_repr_mimebundle.py
@@ -1,0 +1,25 @@
+import pygraphviz as pgv
+import pytest
+
+
+def test_repr_output():
+    A = pgv.AGraph()
+    A.add_path([1, 2, 3, 4])
+    assert repr(A).startswith("<AGraph <Swig Object of type 'Agraph_t")
+    A.layout()
+    assert A._svg_repr().startswith("<?xml version=")
+
+
+def test_mimetype_select():
+    A = pgv.AGraph()
+    A.add_path([1, 2, 3, 4])
+    assert "text/plain" in A._repr_mimebundle_().keys()
+    assert not "image/svg+xml" in A._repr_mimebundle_().keys()
+    A.layout()
+    assert "image/svg+xml" in A._repr_mimebundle_().keys()
+
+
+def test_svg_repr_error():
+    with pytest.raises(AttributeError):
+        A = pgv.AGraph()
+        A._svg_repr()


### PR DESCRIPTION
Addresses feature request #182 .

I can't think of a way to add this method to the test suite, I guess it's too trivial for unit testing.  But if I should try let me know.

A way to manually confirm the functionality:

1. Install `pip install jupyterlab` and open Jupyter in browser (run `jupyter-lab`).
2. Create/open a new Notebook.
3. Run the following code in the Notebook:
    
    ```python
    import pygraphviz as pgv
    d = {"1": {"2": None}, "2": {"1": None, "3": None}, "3": {"2": None}}
    A = pgv.AGraph(d)
    A.layout()
    A
    ```

4.  The SVG image of the graph displays automatically.