### PR TITLE
CI: Update circleci container.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     working_directory: ~/repo
     docker:
-      - image: circleci/python:3.8.5-buster
+      - image: cimg/python:3.8
 
     steps:
       - checkout

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -1,5 +1,5 @@
-sphinx==3.4.3
-sphinx_rtd_theme==0.5.1
-sphinx-gallery==0.8.2
+sphinx>=3.4.3
+sphinx_rtd_theme>=0.5.1
+sphinx-gallery>=0.8.2
 matplotlib>=3.3.4
 numpydoc>=1.1


### PR DESCRIPTION
The circleci job is failing on an apt-update: try using one of the newer, recommended containers instead.