### PR TITLE
Proposal: remove the fedora test workflow from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,43 +45,6 @@ jobs:
         pytest --doctest-modules --durations=10 --pyargs pygraphviz
 
 
-  fedora:
-
-    strategy:
-      matrix:
-        release:
-          - 33
-          - 34
-
-    runs-on: Ubuntu-20.04
-    container: 'fedora:${{ matrix.release }}'
-
-    steps:
-
-    - name: Checkout pygraphviz
-      uses: actions/checkout@v2
-
-    - name: Install graphviz
-      run: sudo dnf install --nogpg -y graphviz graphviz-devel
-
-    - name: Install Python developer tools
-      run: sudo dnf install --nogpg -y python3-devel
-
-    - name: Install gcc
-      run: sudo dnf install -y --nogpg gcc
-
-    - name: Install packages
-      run: |
-        pip install --upgrade pip wheel setuptools
-        pip install -r requirements/test.txt
-        pip install .
-        pip list
-
-    - name: Test pygraphviz
-      run: |
-        pytest --doctest-modules --durations=10 --pyargs pygraphviz
-
-
   brew:
 
     runs-on: macOS-latest


### PR DESCRIPTION
The solution for testing on fedora has always been fragile and appears to have broken again. AFAICT the `setup-python` action is not working inside the `fedora` job, as `python` is not recognized in these workflows.

I propose to remove the fedora workflow for now, as it seems to be causing more problems than it catches. We can always update/add back distro-specific workflows later on if they will be useful.