### PR TITLE
Add workflow_dispatch to enable manual triggering of conda workflows.

### DIFF
--- a/.github/workflows/conda-macos.yml
+++ b/.github/workflows/conda-macos.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     # Run this workflow once a week
     - cron: "0 0 * * 0"
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/conda-ubuntu.yml
+++ b/.github/workflows/conda-ubuntu.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     # Run this workflow once a week
     - cron: "0 0 * * 0"
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/conda-windows.yml
+++ b/.github/workflows/conda-windows.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     # Run this workflow once a week
     - cron: "0 0 * * 0"
+  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
Once on `main`, should enable re-running the conda-forge workflows via button-press in the GitHub UI