### PR TITLE
Update conda, use explicit Python version in CI.

### DIFF
--- a/.github/workflows/conda-macos.yml
+++ b/.github/workflows/conda-macos.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Install and Test
         shell: bash -l {0}
         run: |
-          conda create -n pgv-testenv
+          conda update conda
+          conda create -n pgv-testenv python=${{ matrix.python-version }}
           conda activate pgv-testenv
           conda install --channel conda-forge pygraphviz
           conda install pytest

--- a/.github/workflows/conda-ubuntu.yml
+++ b/.github/workflows/conda-ubuntu.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Install and Test
         shell: bash -l {0}
         run: |
-          conda create -n pgv-testenv
+          conda update conda
+          conda create -n pgv-testenv python=${{ matrix.python-version }}
           conda activate pgv-testenv
           conda install --channel conda-forge pygraphviz
           conda install pytest

--- a/.github/workflows/conda-windows.yml
+++ b/.github/workflows/conda-windows.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Install and Test
         shell: bash -l {0}
         run: |
-          conda create -n pgv-testenv
+          conda update conda
+          conda create -n pgv-testenv python=${{ matrix.python-version }}
           conda activate pgv-testenv
           conda install --channel conda-forge pygraphviz
           conda install pytest


### PR DESCRIPTION
Some conda versions < 4.11 fail to parse the Python version `3.10` correctly, see e.g. conda/conda#10969

This updates the conda-forge test workflows by:
 1. Updating conda prior to environment creation
 2. Being explicit about which Python version to use in the conda env