### PR TITLE
Try mambaforge

### DIFF
--- a/.github/workflows/conda-macos.yml
+++ b/.github/workflows/conda-macos.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Install and Test
         shell: bash -l {0}
         run: |
-          conda create -n pgv-testenv python=${{ matrix.python-version }}
+          mamba create -n pgv-testenv python=${{ matrix.python-version }}
           conda activate pgv-testenv
-          conda install --channel conda-forge pygraphviz
-          conda install --channel conda-forge pytest
+          mamba install --channel conda-forge pygraphviz
+          mamba install --channel conda-forge pytest
           pytest --pyargs pygraphviz

--- a/.github/workflows/conda-macos.yml
+++ b/.github/workflows/conda-macos.yml
@@ -14,9 +14,13 @@ jobs:
         python-version: [3.8, 3.9, "3.10"]
     steps:
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - name: Setup conda with mambaforge
+        uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
           python-version: ${{ matrix.python-version }}
 
       - name: Conda info

--- a/.github/workflows/conda-ubuntu.yml
+++ b/.github/workflows/conda-ubuntu.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash -l {0}
         run: |
           mamba create -n pgv-testenv python=${{ matrix.python-version }}
-          mamba activate pgv-testenv
+          conda activate pgv-testenv
           mamba install --channel conda-forge pygraphviz
           mamba install --channel conda-forge pytest
           pytest --pyargs pygraphviz

--- a/.github/workflows/conda-ubuntu.yml
+++ b/.github/workflows/conda-ubuntu.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Install and Test
         shell: bash -l {0}
         run: |
-          conda create -n pgv-testenv python=${{ matrix.python-version }}
-          conda activate pgv-testenv
-          conda install --channel conda-forge pygraphviz
-          conda install --channel conda-forge pytest
+          mamba create -n pgv-testenv python=${{ matrix.python-version }}
+          mamba activate pgv-testenv
+          mamba install --channel conda-forge pygraphviz
+          mamba install --channel conda-forge pytest
           pytest --pyargs pygraphviz

--- a/.github/workflows/conda-ubuntu.yml
+++ b/.github/workflows/conda-ubuntu.yml
@@ -14,9 +14,13 @@ jobs:
         python-version: [3.8, 3.9, "3.10"]
     steps:
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - name: Setup conda with mambaforge
+        uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
           python-version: ${{ matrix.python-version }}
 
       - name: Conda info

--- a/.github/workflows/conda-windows.yml
+++ b/.github/workflows/conda-windows.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Install and Test
         shell: bash -l {0}
         run: |
-          conda create -n pgv-testenv python=${{ matrix.python-version }}
+          mamba create -n pgv-testenv python=${{ matrix.python-version }}
           conda activate pgv-testenv
-          conda install --channel conda-forge pygraphviz
-          conda install --channel conda-forge pytest
+          mamba install --channel conda-forge pygraphviz
+          mamba install --channel conda-forge pytest
           pytest --pyargs pygraphviz

--- a/.github/workflows/conda-windows.yml
+++ b/.github/workflows/conda-windows.yml
@@ -14,9 +14,13 @@ jobs:
         python-version: [3.8, 3.9, "3.10"]
     steps:
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - name: Setup conda with mambaforge
+        uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
           python-version: ${{ matrix.python-version }}
 
       - name: Conda info


### PR DESCRIPTION
Modifies the CI workflows that test pygraphviz from the `conda-forge` channel to use mambaforge instead, the results of which can be seen in manually triggered workflow runs, e.g.
 - macos: https://github.com/pygraphviz/pygraphviz/actions/runs/1694667563
 - ubuntu: https://github.com/pygraphviz/pygraphviz/actions/runs/1694640274
 - windows: https://github.com/pygraphviz/pygraphviz/actions/runs/1694668339

Note that everything succeeds as expected, though the workflows do emit a warning that mamba support is still experimental.