### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ authors = {
 }
 url = "http://pygraphviz.github.io"
 project_urls = {
+    "Documentation": "https://pygraphviz.github.io/documentation/stable/",
     "Source": "https://github.com/pygraphviz/pygraphviz",
 },
 download_url = "https://pypi.python.org/pypi/pygraphviz"

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ authors = {
     "Renieris": ("Manos Renieris", ""),
 }
 url = "http://pygraphviz.github.io"
+project_urls = {
+    "Source": "https://github.com/pygraphviz/pygraphviz",
+},
 download_url = "https://pypi.python.org/pypi/pygraphviz"
 platforms = ["Linux", "Mac OSX", "Microsoft :: Windows"]
 keywords = ["Networks", "Graph Visualization", "network", "graph", "graph drawing"]
@@ -98,6 +101,7 @@ if __name__ == "__main__":
         license=license,
         platforms=platforms,
         url=url,
+        project_urls=project_urls,
         download_url=download_url,
         classifiers=classifiers,
         packages=packages,


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)