### PR TITLE
Ensure define_macros remains a list on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ package_data = {
 if __name__ == "__main__":
     define_macros = []
     if sys.platform == "win32":
-        define_macros = define_macros.append(("GVDLL", None))
+        define_macros.append(("GVDLL", None))
 
     extension = [
         Extension(


### PR DESCRIPTION
Faced issues building pygraphviz with Graphviz 3+, since specifying `/DGVDLL` is now mandatory.

```
>>> define_macros = []
>>> define_macros = define_macros.append(("GVDLL", None))
>>> print(define_macros)
None
```

Closes #408 