### PR TITLE
Close all references to fname before calling unlink(fname)

### DIFF
--- a/pygraphviz/tests/test_edge_attributes.py
+++ b/pygraphviz/tests/test_edge_attributes.py
@@ -49,6 +49,8 @@ def test_anonymous_edges():
 
     ans = """graph test { a -- b [label=edge1]; a -- b [label=edge2]; }"""
     assert stringify(A) == " ".join(ans.split())
+
+    A.close()
     os.unlink(fname)
 
 

--- a/pygraphviz/tests/test_readwrite.py
+++ b/pygraphviz/tests/test_readwrite.py
@@ -17,6 +17,9 @@ def test_readwrite():
     assert A == B
     assert B == A
     assert B is not A
+
+    A.close()
+    B.close()
     os.unlink(fname)
 
 
@@ -33,4 +36,7 @@ def test_readwrite_pathobj():
     assert A == B
     assert B == A
     assert B is not A
+
+    A.close()
+    B.close()
     os.unlink(fname)


### PR DESCRIPTION
On Windows, with PyPy, I saw these errors while running the tests:

```
================================== FAILURES ===================================
____________________________ test_anonymous_edges _____________________________

    def test_anonymous_edges():
        text_graph = (
            b"""graph test {\n a -- b [label="edge1"];\n a -- b [label="edge2"];\n }"""
        )
    
        import os
        import tempfile
    
        fd, fname = tempfile.mkstemp()
        os.write(fd, text_graph)
        os.close(fd)
        A = pgv.AGraph(fname)
    
        ans = """graph test { a -- b [label=edge1]; a -- b [label=edge2]; }"""
        assert stringify(A) == " ".join(ans.split())
>       os.unlink(fname)
E       PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\VSSADM~1\\AppData\\Local\\Temp\\tmpwao9ujdz'

..\_test_env\lib\site-packages\pygraphviz\tests\test_edge_attributes.py:52: PermissionError
_______________________________ test_readwrite ________________________________

    def test_readwrite():
        A = pgv.AGraph(name="test graph")
        A.add_path([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
        the_file = tempfile.NamedTemporaryFile(delete=False)
        fname = the_file.name
        # Make sure it can be opened for writing again on Win32
        the_file.close()
        # Pass a string to trigger the code paths that close the newly created file handle
        A.write(fname)
        B = pgv.AGraph(fname)
        assert A == B
        assert B == A
        assert B is not A
>       os.unlink(fname)
E       PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\VSSADM~1\\AppData\\Local\\Temp\\tmpb257v8ui'

..\_test_env\lib\site-packages\pygraphviz\tests\test_readwrite.py:20: PermissionError
___________________________ test_readwrite_pathobj ____________________________

    def test_readwrite_pathobj():
        A = pgv.AGraph(name="test graph")
        A.add_path([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
        the_file = tempfile.NamedTemporaryFile(delete=False)
        fname = pathlib.Path(the_file.name)
        # Make sure it can be opened for writing again on Win32
        the_file.close()
        # Pass a string to trigger the code paths that close the newly created file handle
        A.write(fname)
        B = pgv.AGraph(fname)
        assert A == B
        assert B == A
        assert B is not A
>       os.unlink(fname)
E       PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\VSSADM~1\\AppData\\Local\\Temp\\tmpsrfy0_t_'

..\_test_env\lib\site-packages\pygraphviz\tests\test_readwrite.py:36: PermissionError
```