### PR TITLE
Announce support for Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11-dev"]
 
     steps:
 
@@ -121,7 +121,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11-dev"]
 
     steps:
 
@@ -164,7 +164,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11-dev"]
 
     steps:
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
 The 3.11.0 candidate 1 was released Monday, 2022-08-08. We've been testing against 3.11-dev for sometime and haven't seen any issues.

3.11.0 final is expected to be released on Monday, 2022-10-03. If we run into any 3.11 issues, we can address them and make a 1.10.1 release.
