### PR TITLE
Move modifications for proper file closing from generated `graphviz_wrap.c` to swig file

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -1518,7 +1518,7 @@ class AGraph:
 
         gvc = gv.gvContext()
         gv.gvLayout(gvc, self.handle, prog)
-        gv.gvRender(gvc, self.handle, format=b"dot", out=None)
+        gv.gvRender(gvc, self.handle, format=b"dot", output_file=None)
 
         gv.gvFreeLayout(gvc, self.handle)
         gv.gvFreeContext(gvc)

--- a/pygraphviz/graphviz.py
+++ b/pygraphviz/graphviz.py
@@ -81,11 +81,11 @@ def agraphnew(name,strict=False,directed=False):
 def agclose(g):
     return _graphviz.agclose(g)
 
-def agread(file, arg2):
-    return _graphviz.agread(file, arg2)
+def agread(input_file, arg2):
+    return _graphviz.agread(input_file, arg2)
 
-def agwrite(g, file):
-    return _graphviz.agwrite(g, file)
+def agwrite(g, output_file):
+    return _graphviz.agwrite(g, output_file)
 
 def agisundirected(g):
     return _graphviz.agisundirected(g)
@@ -252,8 +252,8 @@ def gvLayout(gvc, g, prog):
 def gvFreeLayout(gvc, g):
     return _graphviz.gvFreeLayout(gvc, g)
 
-def gvRender(gvc, g, format, out=None):
-    return _graphviz.gvRender(gvc, g, format, out)
+def gvRender(gvc, g, format, output_file=None):
+    return _graphviz.gvRender(gvc, g, format, output_file)
 
 def gvRenderFilename(gvc, g, format, filename):
     return _graphviz.gvRenderFilename(gvc, g, format, filename)

--- a/pygraphviz/graphviz_wrap.c
+++ b/pygraphviz/graphviz_wrap.c
@@ -3234,15 +3234,20 @@ SWIGINTERN PyObject *_wrap_agread(PyObject *SWIGUNUSEDPARM(self), PyObject *args
   arg2 = (Agdisc_t *)(argp2);
   {
     result = (Agraph_t *)agread(arg1,arg2);
-    fclose(arg1);
     if (!result) {
       PyErr_SetString(PyExc_ValueError,"agread: bad input data");
       return NULL;
     }
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_Agraph_t, 0 |  0 );
+  {
+    fclose(arg1);
+  }
   return resultobj;
 fail:
+  {
+    fclose(arg1);
+  }
   return NULL;
 }
 


### PR DESCRIPTION
See [the discussion in 415](https://github.com/pygraphviz/pygraphviz/pull/415#issuecomment-1210458418).

The simple attempt results in `dup` being added to more wrapped functions, which causes an infinite hang in the `pygraphviz/tests/test_drawing.py::test_drawing_no_error_with_no_layout`, at least locally.