### PR TITLE
Fix passthrough of graph attributes when copying

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -1021,7 +1021,7 @@ class AGraph:
         Versions <=1.6 made a copy by writing and the reading a dot string.
         This version loads a new graph with nodes, edges and attributes.
         """
-        G = self.__class__(directed=self.is_directed())
+        G = self.__class__(directed=self.is_directed(), strict=self.strict)
         for node in self.nodes():
             G.add_node(node)
             G.get_node(node).attr.update(self.get_node(node).attr)

--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -1021,7 +1021,9 @@ class AGraph:
         Versions <=1.6 made a copy by writing and the reading a dot string.
         This version loads a new graph with nodes, edges and attributes.
         """
-        G = self.__class__(directed=self.is_directed(), strict=self.strict)
+        G = self.__class__(
+            directed=self.is_directed(), strict=self.strict, name=self.name
+        )
         for node in self.nodes():
             G.add_node(node)
             G.get_node(node).attr.update(self.get_node(node).attr)

--- a/pygraphviz/tests/test_graph.py
+++ b/pygraphviz/tests/test_graph.py
@@ -304,6 +304,11 @@ class TestGraph(unittest.TestCase):
         G_copy = G.copy()
         assert not G_copy.is_directed()
 
+        # Similarly with the strict attr when copying: see gh-426
+        A = pgv.AGraph(strict=False, directed=True)
+        assert A.strict is False
+        assert A.copy().strict is False
+
     def test_add_path(self):
         A = pgv.AGraph()
         A.add_path([1, 2, 3])

--- a/pygraphviz/tests/test_graph.py
+++ b/pygraphviz/tests/test_graph.py
@@ -304,10 +304,11 @@ class TestGraph(unittest.TestCase):
         G_copy = G.copy()
         assert not G_copy.is_directed()
 
-        # Similarly with the strict attr when copying: see gh-426
-        A = pgv.AGraph(strict=False, directed=True)
-        assert A.strict is False
-        assert A.copy().strict is False
+        # Similarly with the strict and name attrs when copying: see gh-426
+        A = pgv.AGraph(strict=False, directed=True, name="foobar")
+        AC = A.copy()
+        assert AC.strict == A.strict
+        assert AC.name == A.name
 
     def test_add_path(self):
         A = pgv.AGraph()


### PR DESCRIPTION
Fixes the carry over of the `name` and `strict` attributes when copying. Fixes #426 .