### PR TITLE
Add a note for brew install instructions.

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -69,6 +69,19 @@ Homebrew
     $ brew install graphviz
     $ pip install pygraphviz
 
+.. note::
+
+   Graphviz may be installed in a location that is not on the default search
+   path.
+   In this case, it may be necessary to manually specify the path to the
+   graphviz include and/or library directories, e.g. ::
+
+       pip install --global-option="-I$(brew --prefix graphviz)/include" \
+                   --global-option="-L$(brew --prefix graphviz)/lib/" \
+                   pygraphviz
+
+   See the Advanced section for details.
+
 MacPorts
 ~~~~~~~~
 


### PR DESCRIPTION
It seems `brew` no longer reliably installs graphviz on the default paths where the header files can be discovered. This is likely dependent on the version of macos, brew, and perhaps graphviz.

Updates the install instructions with brew-specific instructions for specifying include and library dirs manually.

Closes #443, insofar as it's possible to "close" the continual installation issues :)