### PR TITLE
CI: Add circleci artifact redirector token.

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -8,5 +8,6 @@ jobs:
         uses: larsoner/circleci-artifacts-redirector-action@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          api-token: ${{ secrets.CIRCLECI_ARTIFACT_REDIRECTOR_TOKEN }}
           artifact-path: 0/doc/build/dist/index.html
           circleci-jobs: build


### PR DESCRIPTION
Fixes issues in CI with circleci doc artifact link. Followed the procedure described in larsoner/circleci-artifacts-redirector-action#40.