### PR TITLE
Add pep517 flag for config-settings

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -146,7 +146,7 @@ Manual download
 
 .. code-block:: console
 
-    PS C:\> python -m pip install --use-pep517
+    PS C:\> python -m pip install --use-pep517 `
                   --config-setting="--global-option=build_ext" `
                   --config-setting="--global-option="-IC:\Program Files\Graphviz\include" `
                   --config-setting="--global-option="-LC:\Program Files\Graphviz\lib" `
@@ -158,7 +158,7 @@ Chocolatey
 .. code-block:: console
 
     PS C:\> choco install graphviz
-    PS C:\> python -m pip install --use-pep517
+    PS C:\> python -m pip install --use-pep517 `
                   --config-setting="--global-option=build_ext" `
                   --config-setting="--global-option="-IC:\Program Files\Graphviz\include" `
                   --config-setting="--global-option="-LC:\Program Files\Graphviz\lib" `

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -76,7 +76,8 @@ Homebrew
    In this case, it may be necessary to manually specify the path to the
    graphviz include and/or library directories, e.g. ::
 
-       pip install --config-setting="--global-option=build_ext" \
+       pip install --use-pep517 \
+                   --config-setting="--global-option=build_ext" \
                    --config-setting="--build-option=-I$(brew --prefix graphviz)/include/" \
                    --config-setting="--build-option=-L$(brew --prefix graphviz)/lib/" \
                    pygraphviz
@@ -90,7 +91,8 @@ MacPorts
 
     $ port install graphviz
     $ pip install pygraphviz
-    $ pip install --config-setting="--global-option=build_ext" \
+    $ pip install --use-pep517 \
+                  --config-setting="--global-option=build_ext" \
                   --config-setting="--global-option="-I/opt/local/include/" \
                   --config-setting="--global-option="-L/opt/local/lib/" \
                   pygraphviz
@@ -144,7 +146,8 @@ Manual download
 
 .. code-block:: console
 
-    PS C:\> python -m pip install --config-setting="--global-option=build_ext" `
+    PS C:\> python -m pip install --use-pep517
+                  --config-setting="--global-option=build_ext" `
                   --config-setting="--global-option="-IC:\Program Files\Graphviz\include" `
                   --config-setting="--global-option="-LC:\Program Files\Graphviz\lib" `
                   pygraphviz
@@ -155,7 +158,8 @@ Chocolatey
 .. code-block:: console
 
     PS C:\> choco install graphviz
-    PS C:\> python -m pip install --config-setting="--global-option=build_ext" `
+    PS C:\> python -m pip install --use-pep517
+                  --config-setting="--global-option=build_ext" `
                   --config-setting="--global-option="-IC:\Program Files\Graphviz\include" `
                   --config-setting="--global-option="-LC:\Program Files\Graphviz\lib" `
                   pygraphviz


### PR DESCRIPTION
Following a pip version update, the `--config-settings` feature will no longer be supported by default. As a result, an error message will be displayed suggesting alternative usage:

> DEPRECATION: Config settings are ignored for project pygraphviz from https://files.pythonhosted.org/packages/ee/7e/7366c082f959db7ee18a16fc38dc594158ede65ca789bef87751ed5130c7/pygraphviz-1.10.zip. pip 23.3 will enforce this behaviour change. A possible replacement is to use --use-pep517 or add a pyproject.toml file to the project.

In response, this pr adds an option `--use-pep517` that is documented within the installation instructions.

<details><summary>Screenshots</summary>
<h6>Before adding <code>--use-pep517</code></h6>
<img width="762" alt="Before add --use-pep517" src="https://github.com/pygraphviz/pygraphviz/assets/59875060/0021034d-a690-46f0-8d82-aec80ecb6c92">
<h6>After adding <code>--use-pep517</code></h6>
<img width="762" alt="After add --use-pep517" src="https://github.com/pygraphviz/pygraphviz/assets/59875060/8f233351-0b68-4ea8-958a-e2a03777d827">
</details>