### PR TITLE
Avoid subprocess window creation with agraph.AGraph._run_prog

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -1378,6 +1378,9 @@ class AGraph:
         runprog = r'"%s"' % self._get_prog(prog)
         cmd = " ".join([runprog, args])
         dotargs = shlex.split(cmd)
+        popen_kwargs = dict()
+        if hasattr(subprocess, 'CREATE_NO_WINDOW'):  # Only on Windows OS
+            popen_kwargs.update(creationflags=subprocess.CREATE_NO_WINDOW)
         p = subprocess.Popen(
             dotargs,
             shell=False,
@@ -1385,6 +1388,7 @@ class AGraph:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             close_fds=False,
+            **popen_kwargs,
         )
         (child_stdin, child_stdout, child_stderr) = (p.stdin, p.stdout, p.stderr)
         # Use threading to avoid blocking


### PR DESCRIPTION
Hi pygraphviz team,

Thanks for this great project!

### Context
I'm using `pygraphviz` through [`networkx`](https://github.com/networkx/networkx) for some python widgets that are added to a host application in the form of a plugin.

In Windows OS, running [`networkx.drawing.pygraphviz_layout`](https://github.com/networkx/networkx/blob/3c0f096f66ab352cfaf8dbe2d5fc5731cbbc4338/networkx/drawing/nx_agraph.py#L261C5-L261C22) leads to a terminal window appearing and disappearing very quickly. This seems to happen exactly during execution of [`pygraphviz.agraph.AGraph._run_prog`](https://github.com/pygraphviz/pygraphviz/blob/fce4667903d56f4cd0d4f5e7770b238f211d5481/pygraphviz/agraph.py#L1381-L1388) on the subprocess call:

https://github.com/pygraphviz/pygraphviz/blob/fce4667903d56f4cd0d4f5e7770b238f211d5481/pygraphviz/agraph.py#L1381-L1388

### Changes in this PR

This PR proposes that if [`subprocess.CREATE_NO_WINDOW`](https://docs.python.org/3/library/subprocess.html#subprocess.CREATE_NO_WINDOW) is available (Python-3.7+ & Windows OS), then it will be passed as a creation flag to the subprocess. The python docs state this flag is for:
> A [Popen](https://docs.python.org/3/library/subprocess.html#subprocess.Popen) creationflags parameter to specify that a new process will not create a window.

An example with this change with the python widgets I'm using (the top left selection triggers the `networkx` call, and on the bottom section we see the graph GUI that has been created through `pygraphviz`):

| Before this PR | With this PR |
| ------ | ------ |
| ![subprocess_window](https://github.com/pygraphviz/pygraphviz/assets/8294116/3d87c03e-a41e-4fde-a5aa-f95f8027d9bf) | ![subprocess_no_window](https://github.com/pygraphviz/pygraphviz/assets/8294116/34ba8d50-641b-4946-8830-b9ed20d22ee0) |

---

I aimed at making the changes not invasive, though I'd be happy to make adjustments that you see fit; please let me know your thoughts,

Thanks!

-Chris


