### PR TITLE
Fix segfault from repr attempting to access attrs on uninitialized instance

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -226,6 +226,8 @@ class AGraph:
         return self.string()
 
     def __repr__(self):
+        if self.handle is None:
+            return super().__repr__()
         name = gv.agnameof(self.handle)
         if name is None:
             return f"<AGraph {self.handle}>"

--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -228,8 +228,7 @@ class AGraph:
     def __repr__(self):
         if self.handle is None:
             return super().__repr__()
-        name = gv.agnameof(self.handle)
-        if name is None:
+        if (name := gv.agnameof(self.handle)) is None:
             return f"<AGraph {self.handle}>"
         return f"<AGraph {name} {self.handle}>"
 

--- a/pygraphviz/tests/test_graph.py
+++ b/pygraphviz/tests/test_graph.py
@@ -520,3 +520,10 @@ def test_agraph_has_edge_single_input_parsing():
     A = pgv.AGraph({0: [1], 1: [0, 2], 2: [1]})
     assert A.has_edge((0, 1))
     assert not A.has_edge((0, 3))
+
+
+def test_repr_on_incomplete_initialization():
+    """Smoke test to ensure no segfaults from accessing uninitialized attributes
+    in __repr__ when object initialization fails. See gh-519."""
+    with pytest.raises(TypeError, match="Unrecognized input"):
+        A = pgv.AGraph(object())


### PR DESCRIPTION
Fixes #519 

IIUC `__init__` already uses `handle=None` as an [indicator that something may have gone wrong during initialization](https://github.com/pygraphviz/pygraphviz/blob/fce4667903d56f4cd0d4f5e7770b238f211d5481/pygraphviz/agraph.py#L118). This PR leverages this fact to avoid calling the low-level `gv.agnameof` on `self.handle` when `self.handle is None`.

@aaronzo the test and proposed fix are basically ripped right out of your suggestions in #519 so I went ahead and added you as a co-author - hopefully that's okay! Should any other corner-cases be added to the test suite to ensure this fix covers the full gamut?