### PR TITLE
Add cibuildwheel

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,0 +1,149 @@
+name: Wheels
+
+on:
+  pull_request:
+  push:
+    tags:
+      - "v*"
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: 3.x
+
+      - name: Build sdist
+        run: >
+          pip install build
+          &&  python -m build --sdist . --outdir dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pypi-artifacts
+          path: ${{ github.workspace }}/dist/*.tar.gz
+
+
+  build_wheels:
+    name: Build wheels for ${{matrix.arch}} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            arch: x86_64
+            INCLUDE_DIR: "/usr/include/graphviz/"
+            LIB_DIR: "/usr/lib/graphviz/"
+          - os: macos-14
+            arch: arm64
+            INCLUDE_DIR: "/Users/runner/micromamba/envs/build/include"
+            LIB_DIR: "/Users/runner/micromamba/envs/build/lib"
+          - os: macos-13
+            arch: x86_64
+            INCLUDE_DIR: "/Users/runner/micromamba/envs/build/include"
+            LIB_DIR: "/Users/runner/micromamba/envs/build/lib"
+          - os: windows-latest
+            arch: win_amd64
+            INCLUDE_DIR: "C:\\Users\\runneradmin\\micromamba\\envs\\build\\Library\\include"
+            LIB_DIR: "C:\\Users\\runneradmin\\micromamba\\envs\\build\\Library\\lib"
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: 3.x
+
+      - name: Setup Micromamba Python ${{ matrix.python-version }}
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: build
+          init-shell: bash
+          create-args: >-
+            python=${{ matrix.python-version }} graphviz=12.0.0 --channel conda-forge
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install --upgrade cibuildwheel delvewheel
+
+      - name: Build Wheels
+        run: cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_SKIP: "pp* cp36-* cp37-* cp38-* cp39-* *-musllinux*"
+          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"
+          CIBW_BEFORE_ALL_LINUX: dnf install -y graphviz graphviz-devel
+          CIBW_BUILD: "cp310*${{ matrix.arch }} cp311*${{ matrix.arch }} cp312*${{ matrix.arch }}"
+          CIBW_TEST_REQUIRES: pytest
+          MACOSX_DEPLOYMENT_TARGET: "10.13"
+          CIBW_ENVIRONMENT_WINDOWS: >
+            PATH="C:\\Users\\runneradmin\\micromamba\\envs\\build\\Library\\bin;${PATH}"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
+            delvewheel show {wheel}
+            && delvewheel repair -w {dest_dir} {wheel}
+          # FIXME: Remove this one the CLI is no longer needed!
+          CIBW_BEFORE_ALL_MACOS: brew install graphviz
+          CIBW_TEST_COMMAND: >
+            python -c "import pygraphviz; print(f'pygraphviz v{pygraphviz.__version__}')"
+            && pytest --doctest-modules --durations=10 --pyargs pygraphviz -k "not (test_drawing_no_error_with_no_layout or test_drawing_png_output_with_NULL_smoketest or test_drawing_to_create_dot_string or test_drawing_makes_file or test_drawing_makes_file1 or test_layout)"
+          CIBW_BUILD_FRONTEND: 'pip; args: --config-settings="--global-option=build_ext" --config-settings="--global-option=-I${{ matrix.INCLUDE_DIR }}" --config-settings="--global-option=-L${{ matrix.LIB_DIR }}"'
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+            DYLD_LIBRARY_PATH=/Users/runner/micromamba/envs/build/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+              
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pypi-artifacts-${{ matrix.os }}-${{ matrix.arch }}
+          path: ${{ github.workspace }}/wheelhouse/*.whl
+
+
+  show-artifacts:
+    needs: [ build_sdist, build_wheels ]
+    name: "Show artifacts"
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: pypi-artifacts*
+        path: ${{ github.workspace }}/dist
+        merge-multiple: true
+
+    - shell: bash
+      run: |
+        ls -lh ${{ github.workspace }}/dist
+
+
+  publish-artifacts-pypi:
+    needs: [ build_sdist, build_wheels ]
+    name: "Publish to PyPI"
+    runs-on: ubuntu-22.04
+    # upload to PyPI for every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: pypi-artifacts*
+        path: ${{ github.workspace }}/dist
+        merge-multiple: true
+
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_PASSWORD }}
+        print_hash: true

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -13,7 +13,6 @@ permissions:
   contents: read
 
 jobs:
-
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-22.04
@@ -36,7 +35,6 @@ jobs:
         with:
           name: pypi-artifacts
           path: ${{ github.workspace }}/dist/*.tar.gz
-
 
   build_wheels:
     name: Build wheels for ${{matrix.arch}} on ${{ matrix.os }}
@@ -104,44 +102,42 @@ jobs:
           CIBW_BUILD_FRONTEND: 'pip; args: --config-settings="--global-option=build_ext" --config-settings="--global-option=-I${{ matrix.INCLUDE_DIR }}" --config-settings="--global-option=-L${{ matrix.LIB_DIR }}"'
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
             DYLD_LIBRARY_PATH=/Users/runner/micromamba/envs/build/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
-              
+
       - uses: actions/upload-artifact@v4
         with:
           name: pypi-artifacts-${{ matrix.os }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/wheelhouse/*.whl
 
-
   show-artifacts:
-    needs: [ build_sdist, build_wheels ]
+    needs: [build_sdist, build_wheels]
     name: "Show artifacts"
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: pypi-artifacts*
-        path: ${{ github.workspace }}/dist
-        merge-multiple: true
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: pypi-artifacts*
+          path: ${{ github.workspace }}/dist
+          merge-multiple: true
 
-    - shell: bash
-      run: |
-        ls -lh ${{ github.workspace }}/dist
-
+      - shell: bash
+        run: |
+          ls -lh ${{ github.workspace }}/dist
 
   publish-artifacts-pypi:
-    needs: [ build_sdist, build_wheels ]
+    needs: [build_sdist, build_wheels]
     name: "Publish to PyPI"
     runs-on: ubuntu-22.04
     # upload to PyPI for every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: pypi-artifacts*
-        path: ${{ github.workspace }}/dist
-        merge-multiple: true
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: pypi-artifacts*
+          path: ${{ github.workspace }}/dist
+          merge-multiple: true
 
-    - uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_PASSWORD }}
-        print_hash: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_PASSWORD }}
+          print_hash: true

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -98,11 +98,9 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
             delvewheel show {wheel}
             && delvewheel repair -w {dest_dir} {wheel}
-          # FIXME: Remove this one the CLI is no longer needed!
-          CIBW_BEFORE_ALL_MACOS: brew install graphviz
           CIBW_TEST_COMMAND: >
             python -c "import pygraphviz; print(f'pygraphviz v{pygraphviz.__version__}')"
-            && pytest --doctest-modules --durations=10 --pyargs pygraphviz -k "not (test_drawing_no_error_with_no_layout or test_drawing_png_output_with_NULL_smoketest or test_drawing_to_create_dot_string or test_drawing_makes_file or test_drawing_makes_file1 or test_layout)"
+            && pytest --doctest-modules --durations=10 --pyargs pygraphviz
           CIBW_BUILD_FRONTEND: 'pip; args: --config-settings="--global-option=build_ext" --config-settings="--global-option=-I${{ matrix.INCLUDE_DIR }}" --config-settings="--global-option=-L${{ matrix.LIB_DIR }}"'
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
             DYLD_LIBRARY_PATH=/Users/runner/micromamba/envs/build/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -87,6 +87,7 @@ jobs:
         env:
           CIBW_SKIP: "pp* cp36-* cp37-* cp38-* cp39-* *-musllinux*"
           CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_28"
+          CIBW_BEFORE_ALL: "dot -c"
           CIBW_BEFORE_ALL_LINUX: dnf install -y graphviz graphviz-devel
           CIBW_BUILD: "cp310*${{ matrix.arch }} cp311*${{ matrix.arch }} cp312*${{ matrix.arch }}"
           CIBW_TEST_REQUIRES: pytest


### PR DESCRIPTION
@rossbar this is not ready yet. We are missing:

- Linux wheels
- Figure out if #421 will fix the 8 failing tests I'm skipping here
- Consolidate the configuration, the are many duplicate config stuff across the builds
- Cleanup the GHA a bit, use env vars for directories, etc

However, it is building and creating wheels+sdist and this GHA can upload to releases PyPI if you configure a token for it.
The artifacts can also be downloaded and tested. These are the libs that are getting into the wheel at the moment:

macos:
```
40K libcdt.5.dylib*
115K libcgraph.6.dylib*
184K libexpat.1.9.3.dylib*
614K libgvc.6.dylib*
57K libpathplan.4.dylib*
49K libxdot.4.dylib*
118K libz.1.3.1.dylib*
```

Windows:
```
22K cdt-342f69fc3474f83e64f7adc41ab41c06.dll
101K cgraph-0a3e783e69a7584e6aab91066c42041e.dll
586K gvc-8a9c330349805b089cded3d80a6df4c7.dll
393K libexpat-240eda6cb38cafdca500c9bac45c9e1e.dll
40K pathplan-15678f6e0d92308f4acb1bbfb5ccc80d.dll
27K xdot-2e38ffa2a89bc2ee943b244c5295e4c0.dll
87K zlib-bcc560fd7c0e05149614f4743cc3939c.dll
```

I don't see cairo in there, so there is still some work to do on that front.