### PR TITLE
Drop support for Python 3.10 (SPEC 0)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     working_directory: ~/repo
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.12
 
     steps:
       - checkout

--- a/.github/workflows/conda-macos.yml
+++ b/.github/workflows/conda-macos.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13-dev"]
+        python-version: ["3.11", "3.12", "3.13-dev"]
     steps:
       - name: Setup conda with mambaforge
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/conda-ubuntu.yml
+++ b/.github/workflows/conda-ubuntu.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13-dev"]
+        python-version: ["3.11", "3.12", "3.13-dev"]
     steps:
       - name: Setup conda with mambaforge
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/conda-windows.yml
+++ b/.github/workflows/conda-windows.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13-dev"]
+        python-version: ["3.11", "3.12", "3.13-dev"]
     steps:
       - name: Setup conda with mambaforge
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.12"]
 
     steps:
       - name: Checkout pygraphviz

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Update apt-get
         run: sudo apt-get update

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13-dev", "pypy-3.10"]
+        python-version: ["3.11", "3.12", "3.13-dev", "pypy-3.10"]
 
     steps:
       - name: Checkout pygraphviz
@@ -80,7 +80,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13-dev"]
+        python-version: ["3.11", "3.12", "3.13-dev"]
 
     steps:
       - name: Checkout pygraphviz
@@ -113,7 +113,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13-dev"]
+        python-version: ["3.11", "3.12", "3.13-dev"]
 
     steps:
       - name: Checkout pygraphviz
@@ -153,7 +153,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13-dev"]
+        python-version: ["3.11", "3.12", "3.13-dev"]
 
     steps:
       - name: Checkout pygraphviz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13-dev", "pypy-3.10"]
+        python-version: ["3.11", "3.12", "3.13-dev"]
 
     steps:
       - name: Checkout pygraphviz

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -4,7 +4,7 @@ Install
 
 PyGraphviz requires:
 
-- Python (version 3.10, 3.11, or 3.12)
+- Python (version 3.11, 3.12, or 3.13)
 - `Graphviz <https://www.graphviz.org/>`_ (version 2.46 or later)
 - C/C++ Compiler
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "Python interface to Graphviz"
 readme = "README.rst"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = {text = "BSD-3-Clause"}
 dynamic = ["version"]
 keywords = [
@@ -29,7 +29,6 @@ classifiers = [
     "Programming Language :: C",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
PyPy is still working on 3.11 support (3.12 and 3.13 support hasn't started yet):
https://github.com/pypy/pypy/milestone/15