### PR TITLE
More precise allocation for string copy in SWIG glue

### DIFF
--- a/pygraphviz/graphviz.i
+++ b/pygraphviz/graphviz.i
@@ -7,6 +7,7 @@
 %{
 #include "graphviz/cgraph.h"
 #include "graphviz/gvc.h"
+#include <stddef.h>
 %}
 
 %typemap(in) FILE* input_file (int fd, PyObject *mode_obj, PyObject *mode_byte_obj, char *mode) {
@@ -211,7 +212,7 @@ int      agsafeset(void *obj, char *name, char *value, char *def);
    * @return The equivalent of `val`, as a plain string or HTML-like string, as relevant
    */
   static char *htmlize(Agraph_t *g, const char *name, char *val) {
-    int len;
+    size_t len;
     char *hs;
 
     if (val[0] == '<' && (strcmp(name, "label") == 0 || strcmp(name, "xlabel") == 0)) {

--- a/pygraphviz/graphviz.i
+++ b/pygraphviz/graphviz.i
@@ -7,7 +7,8 @@
 %{
 #include "graphviz/cgraph.h"
 #include "graphviz/gvc.h"
-#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 %}
 
 %typemap(in) FILE* input_file (int fd, PyObject *mode_obj, PyObject *mode_byte_obj, char *mode) {
@@ -218,7 +219,8 @@ int      agsafeset(void *obj, char *name, char *value, char *def);
     if (val[0] == '<' && (strcmp(name, "label") == 0 || strcmp(name, "xlabel") == 0)) {
       len = strlen(val);
       if (val[len - 1] == '>') {
-        hs = strdup(val + 1);
+        hs = malloc(len - 1);
+        memcpy(hs, val + 1, len - 2);
         *(hs+len-2) = '\0';
         val = agstrdup_html(g,hs);
         free(hs);

--- a/pygraphviz/graphviz.py
+++ b/pygraphviz/graphviz.py
@@ -21,7 +21,7 @@ def _swig_repr(self):
         strthis = "proxy of " + self.this.__repr__()
     except __builtin__.Exception:
         strthis = ""
-    return f"<{self.__class__.__module__}.{self.__class__.__name__}; {strthis} >"
+    return "<%s.%s; %s >" % (self.__class__.__module__, self.__class__.__name__, strthis,)
 
 
 def _swig_setattr_nondynamic_instance_variable(set):

--- a/pygraphviz/graphviz_wrap.c
+++ b/pygraphviz/graphviz_wrap.c
@@ -3022,6 +3022,7 @@ static swig_module_info swig_module = {swig_types, 11, 0, 0, 0, 0};
 
 #include "graphviz/cgraph.h"
 #include "graphviz/gvc.h"
+#include <stddef.h>
 
 
 SWIGINTERN swig_type_info*
@@ -3405,7 +3406,7 @@ SWIG_FromCharPtr(const char *cptr)
    * @return The equivalent of `val`, as a plain string or HTML-like string, as relevant
    */
   static char *htmlize(Agraph_t *g, const char *name, char *val) {
-    int len;
+    size_t len;
     char *hs;
 
     if (val[0] == '<' && (strcmp(name, "label") == 0 || strcmp(name, "xlabel") == 0)) {

--- a/pygraphviz/graphviz_wrap.c
+++ b/pygraphviz/graphviz_wrap.c
@@ -3022,7 +3022,8 @@ static swig_module_info swig_module = {swig_types, 11, 0, 0, 0, 0};
 
 #include "graphviz/cgraph.h"
 #include "graphviz/gvc.h"
-#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 
 
 SWIGINTERN swig_type_info*
@@ -3412,7 +3413,8 @@ SWIG_FromCharPtr(const char *cptr)
     if (val[0] == '<' && (strcmp(name, "label") == 0 || strcmp(name, "xlabel") == 0)) {
       len = strlen(val);
       if (val[len - 1] == '>') {
-        hs = strdup(val + 1);
+        hs = malloc(len - 1);
+        memcpy(hs, val + 1, len - 2);
         *(hs+len-2) = '\0';
         val = agstrdup_html(g,hs);
         free(hs);

--- a/pygraphviz/graphviz_wrap.c
+++ b/pygraphviz/graphviz_wrap.c
@@ -3397,38 +3397,41 @@ SWIG_FromCharPtr(const char *cptr)
   }
   
 
-  int agsafeset_label(Agraph_t *g, void *obj, char *name, char *val, char *def)
-{
+  /** create a string as an internally cached HTML-like string, if necessary
+   *
+   * @param g Graph with which to associated new strings
+   * @param name Name of an attribute being created
+   * @param val Value of the attribute being created
+   * @return The equivalent of `val`, as a plain string or HTML-like string, as relevant
+   */
+  static char *htmlize(Agraph_t *g, const char *name, char *val) {
     int len;
     char *hs;
 
     if (val[0] == '<' && (strcmp(name, "label") == 0 || strcmp(name, "xlabel") == 0)) {
-        len = strlen(val);
-        if (val[len-1] == '>') {
-            hs = strdup(val+1);
-                *(hs+len-2) = '\0';
-            val = agstrdup_html(g,hs);
-            free(hs);
-        }
+      len = strlen(val);
+      if (val[len - 1] == '>') {
+        hs = strdup(val + 1);
+        *(hs+len-2) = '\0';
+        val = agstrdup_html(g,hs);
+        free(hs);
+      }
     }
+
+    return val;
+  }
+
+
+  int agsafeset_label(Agraph_t *g, void *obj, char *name, char *val, char *def)
+{
+    val = htmlize(g, name, val);
     return agsafeset(obj, name, val,def);
 }
   
 
   Agsym_t *agattr_label(Agraph_t *g, int kind, char *name, char *val)
 {
-    int len;
-    char *hs;
-
-    if (val[0] == '<' && (strcmp(name, "label") == 0 || strcmp(name, "xlabel") == 0)) {
-        len = strlen(val);
-        if (val[len-1] == '>') {
-            hs = strdup(val+1);
-                *(hs+len-2) = '\0';
-            val = agstrdup_html(g,hs);
-            free(hs);
-        }
-    }
+    val = htmlize(g, name, val);
     return agattr(g, kind, name, val);
 }
   


### PR DESCRIPTION
A few minor commits, then the focus of this series in the final one whose commit message I quote below.

----

This code was over-allocating and then adjusting string content to truncate the copied string. This has a couple of minor weaknesses:
  1. One more byte than necessary is allocated, increasing heap pressure.
  2. Memory safety tools like Address Sanitizer cannot spot 1-byte overruns.

(1) is not significant, but (2) can make it harder to debug memory safety problems. This change tightens the bounds:

```
                           ┌───┬───┬───┬───┬───┬───┐
  original val:            │ < │ f │ o │ o │ > │000│
                           └───┴───┴───┴───┴───┴───┘
                               ┌───┬───┬───┬───┬───┐
  copy before this change:     │ f │ o │ o │000│000│
                               └───┴───┴───┴───┴───┘
                               ┌───┬───┬───┬───┐ ▲
  copy after this change:      │ f │ o │ o │000│ │
                               └───┴───┴───┴───┘ │
                                                 │
                                ASan, Valgrind etc previously did not know
                                  reading or writing this byte should be
                                    considered an out-of-bounds access
```

This change has no effect on unchecked allocation failures in this code. In future, this should probably be improved to check for and handle `NULL` being returned from `malloc`.