### PR TITLE
Fix types

### DIFF
--- a/pygraphviz/graphviz_wrap.c
+++ b/pygraphviz/graphviz_wrap.c
@@ -5447,7 +5447,7 @@ SWIGINTERN PyObject *_wrap_gvRenderData(PyObject *self, PyObject *args) {
   Agraph_t *arg2 = (Agraph_t *) 0 ;
   char *arg3 = (char *) 0 ;
   char **arg4 = (char **) 0 ;
-  unsigned int *arg5 = (unsigned int *) 0 ;
+  size_t *arg5 = (size_t *) 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 = 0 ;
@@ -5456,7 +5456,7 @@ SWIGINTERN PyObject *_wrap_gvRenderData(PyObject *self, PyObject *args) {
   char *buf3 = 0 ;
   int alloc3 = 0 ;
   char *temp4 = 0 ;
-  unsigned int tempn4 ;
+  size_t tempn4 ;
   PyObject *swig_obj[3] ;
   int result;
   


### PR DESCRIPTION
On my machine, running arch linux with graphviz version 13.0.0-1, I got the following error on building pygraphviz.

```
pygraphviz/graphviz_wrap.c: In function ‘_wrap_gvRenderData’:
      pygraphviz/graphviz_wrap.c:5480:50: error: passing argument 5 of ‘gvRenderData’ from incompatible pointer type [-Wincompatible-pointer-types]
       5480 |   result = (int)gvRenderData(arg1,arg2,arg3,arg4,arg5);
            |                                                  ^~~~
            |                                                  |
            |                                                  unsigned int *
      In file included from pygraphviz/graphviz_wrap.c:3024:
      /usr/include/graphviz/gvc.h:99:49: note: expected ‘size_t *’ {aka ‘long unsigned int *’} but argument is of type ‘unsigned int *’
         99 |                          char **result, size_t *length);
            |                                         ~~~~~~~~^~~~~~
      error: command '/usr/bin/gcc' failed with exit code 1
```

Most likely it would be better to just regenerate the file for graphviz 13, but this just works.