### PR TITLE
Fix FILE* resource leak in agwrite() wrapper

### DIFF
--- a/pygraphviz/graphviz.i
+++ b/pygraphviz/graphviz.i
@@ -37,7 +37,7 @@
         mode_byte_obj = PyUnicode_AsUTF8String(mode_obj);
 
         mode = PyBytes_AsString(mode_byte_obj);
-        $1 = fdopen(fd, mode);
+        $1 = fdopen(dup(fd), mode);
         Py_XDECREF(mode_obj);
         Py_XDECREF(mode_byte_obj);
     }
@@ -45,6 +45,10 @@
 
 %typemap(freearg) FILE* input_file {
     fclose($1);
+}
+
+%typemap(freearg) FILE* output_file {
+    if ($1) fclose($1);
 }
 
 

--- a/pygraphviz/graphviz_wrap.c
+++ b/pygraphviz/graphviz_wrap.c
@@ -3601,15 +3601,21 @@ SWIGINTERN PyObject *_wrap_agwrite(PyObject *self, PyObject *args) {
       mode_byte_obj2 = PyUnicode_AsUTF8String(mode_obj2);
       
       mode2 = PyBytes_AsString(mode_byte_obj2);
-      arg2 = fdopen(fd2, mode2);
+      arg2 = fdopen(dup(fd2), mode2);
       Py_XDECREF(mode_obj2);
       Py_XDECREF(mode_byte_obj2);
     }
   }
   result = (int)agwrite(arg1,arg2);
   resultobj = SWIG_From_int((int)(result));
+  {
+    if (arg2) fclose(arg2);
+  }
   return resultobj;
 fail:
+  {
+    if (arg2) fclose(arg2);
+  }
   return NULL;
 }
 
@@ -5379,7 +5385,7 @@ SWIGINTERN PyObject *_wrap_gvRender(PyObject *self, PyObject *args) {
         mode_byte_obj4 = PyUnicode_AsUTF8String(mode_obj4);
         
         mode4 = PyBytes_AsString(mode_byte_obj4);
-        arg4 = fdopen(fd4, mode4);
+        arg4 = fdopen(dup(fd4), mode4);
         Py_XDECREF(mode_obj4);
         Py_XDECREF(mode_byte_obj4);
       }
@@ -5388,9 +5394,15 @@ SWIGINTERN PyObject *_wrap_gvRender(PyObject *self, PyObject *args) {
   result = (int)gvRender(arg1,arg2,arg3,arg4);
   resultobj = SWIG_From_int((int)(result));
   if (alloc3 == SWIG_NEWOBJ) free((char*)buf3);
+  {
+    if (arg4) fclose(arg4);
+  }
   return resultobj;
 fail:
   if (alloc3 == SWIG_NEWOBJ) free((char*)buf3);
+  {
+    if (arg4) fclose(arg4);
+  }
   return NULL;
 }
 


### PR DESCRIPTION
## Description

PR #415 fixed the `fdopen` resource leak for `agread()` by changing to `fdopen(dup(fd), mode)` + `fclose()`. However, the same bug still exists in the `agwrite()` and `gvRender()` wrappers in `graphviz_wrap.c`. This causes **intermittent SIGBUS crashes** in the child graphviz process (`neato`/`dot`) when `_run_prog` writes graph data to a pipe.

### The bug

In `_run_prog`, pygraphviz creates a `subprocess.Popen` with `stdin=PIPE`, giving Python a `BufferedWriter` on the pipe fd. Then `self.write(child_stdin)` passes this Python file object to the SWIG wrapper, which calls:

```c
fd2 = PyObject_AsFileDescriptor(swig_obj[1]);  // get fd from Python's BufferedWriter
arg2 = fdopen(fd2, mode2);                      // create SECOND C FILE* on same fd
result = (int)agwrite(arg1, arg2);              // write graph through C stdio
return resultobj;                               // no fclose — FILE* leaked
```

This creates **two independent I/O buffers on the same fd** — Python's `BufferedWriter` and C's `FILE*`. This is POSIX undefined behavior. On certain platforms (notably CentOS 7.5 / glibc 2.17), the dual-buffering corrupts the data reaching the child process, causing it to crash with **SIGBUS (signal 7)**.

Compare with the **fixed** `agread` wrapper:

```c
arg1 = fdopen(dup(fd1), mode1);  // dup() — FILE* owns its own fd
// ...
fclose(arg1);                     // properly flushed and closed
```

### Evidence: SIGBUS captured

We instrumented `_run_prog` with 8 parallel experiments per draw call. On CentOS 7.5 (graphviz 2.30.1, glibc 2.17, inside Docker containers), we captured:

```
EXP2 subprocess.run (to_string input):  rc=0  stdout=6209 bytes  ← PASS
EXP3 Popen+PipeReader (to_string input): rc=0  stdout=6209 bytes  ← PASS
EXP4 original adag.draw (self.write):    rc=-7  stdout=0 bytes    ← SIGBUS
EXP5 gv.agwrite to raw os.pipe:         6156 bytes               ← PASS
```

- **EXP2/EXP3**: Same graph data sent via `to_string()` + Python I/O (single buffer on fd) → neato works
- **EXP4**: Same graph sent via `self.write()` → SWIG `fdopen` (dual buffer on fd) → neato SIGBUS
- **EXP5**: Same graph sent via `gv.agwrite()` to a raw `os.pipe()` fd (no Python BufferedWriter) → works

The SIGBUS only occurs when both Python's `BufferedWriter` AND the C `FILE*` from `fdopen` exist on the same fd. This confirms the dual-buffering UB is the root cause.

### Failure rate

In a production environment running ~160 parallel graphviz visualization jobs per session:
- 2-6 failures per session (~2-4%)
- 15+ unique hosts affected across 7 sessions
- Failures are sporadic — same host passes and fails at different times
- Only observed on CentOS 7.5 (glibc 2.17); Rocky 8.9 (glibc 2.28) appears to tolerate the UB

### Fix

Apply the same pattern as the `agread` fix from PR #415 to `agwrite` and `gvRender`:

```c
arg2 = fdopen(dup(fd2), mode2);      // dup() gives FILE* its own fd
result = (int)agwrite(arg1, arg2);
fclose(arg2);                         // flush and close the dup'd fd
```

Changes needed:
1. `graphviz_wrap.c` `_wrap_agwrite`: `fdopen(dup(fd2), mode2)` + `fclose(arg2)`
2. `graphviz_wrap.c` `_wrap_gvRender`: `fdopen(dup(fd4), mode4)` + `fclose(arg4)`
3. `graphviz.i`: Add `%typemap(freearg) FILE* output_file { fclose($1); }` and change `$1 = fdopen(fd, mode)` to `$1 = fdopen(dup(fd), mode)` in the FILE* typemap

### Environment

- pygraphviz 1.11
- Python 3.10.12
- graphviz 2.30.1 (CentOS 7.5) and 2.40.1 (Rocky 8.9)
- glibc 2.17 (CentOS 7.5, reproduces) and 2.28 (Rocky 8.9, tolerates UB)
- Linux 4.18.0, Docker containers on LSF farm

### Workaround

Replace `self.write(child_stdin)` in `_run_prog` with `child_stdin.write(self.to_string().encode(self.encoding))`. This keeps only Python's buffer on the fd, avoiding the dual-buffering UB entirely.

### Related

- #213 — original report of the `fdopen` leak (fixed for `agread` only)
- #415 — PR that fixed `agread` but missed `agwrite` and `gvRender`
- #432 — follow-up to move fix from `graphviz_wrap.c` to `graphviz.i`
