### PR TITLE
CI: fix silent Windows failures and duplicate PR runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 name: test
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 env:
   WIN_GRAPHVIZ_URL: "https://gitlab.com/graphviz/graphviz/-/package_files/164443457/download"
@@ -171,6 +178,7 @@ jobs:
       # We need ``python -m pip install -U pip`` b/c Windows won't modify running programs.
       - name: Install packages
         run: |
+          $ErrorActionPreference = 'Stop'
           python -m pip install --upgrade pip
           python -m pip install -r requirements/test.txt
           python -m pip install --config-settings="--global-option=build_ext" `


### PR DESCRIPTION
## Summary

Two small CI fixes for the test workflow:

- **Fix silent Windows build failures**: Add `$ErrorActionPreference = 'Stop'` to the Windows "Install packages" step. Without this, if `pip install .` fails, PowerShell continues to `pip list` which exits 0, marking the step as "success". This masked the actual build failures in #558.

- **Avoid duplicate workflow runs on PRs**: Limit `push` trigger to `main` branch only, so PRs don't trigger both a `push` and `pull_request` run. Add a concurrency group to cancel stale runs when new commits are pushed.

## Test plan

- [x] Verified on fork CI that the workflow triggers correctly via pull_request