### PR TITLE
Add aarch64 wheels for linux to cibuildwheel.

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -25,6 +25,7 @@ jobs:
             macos-15-intel,
             windows-latest,
             ubuntu-24.04-arm,
+            windows-11-arm,
           ]
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -18,13 +18,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-15, macos-15-intel, windows-latest]
+        os: [ubuntu-latest, macos-15, macos-15-intel, windows-latest, ubuntu-24.04-arm]
 
     steps:
       - uses: actions/checkout@v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
 
       - uses: actions/setup-python@v6
         with:
@@ -38,8 +35,6 @@ jobs:
         env:
           CIBW_BUILD: "cp312-* cp313-* cp314-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
-
-          CIBW_ARCHS_LINUX: "auto aarch64"
 
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -25,7 +25,6 @@ jobs:
             macos-15-intel,
             windows-latest,
             ubuntu-24.04-arm,
-            windows-11-arm,
           ]
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -18,8 +18,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-15, macos-15-intel, windows-latest, ubuntu-24.04-arm]
-
+        os:
+          [
+            ubuntu-latest,
+            macos-15,
+            macos-15-intel,
+            windows-latest,
+            ubuntu-24.04-arm,
+          ]
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -35,6 +38,8 @@ jobs:
         env:
           CIBW_BUILD: "cp312-* cp313-* cp314-*"
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
+
+          CIBW_ARCHS_LINUX: "auto aarch64"
 
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
 


### PR DESCRIPTION
An attempt at adding aarch64 wheels for linux to the cibuildwheel action.