### PR TITLE
Update setuptools version requirement in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = 'setuptools.build_meta'
-requires = ['setuptools>=61.2', "swig>4.1.0"]
+requires = ['setuptools>=78', "swig>4.1.0"]
 
 [project]
 name = "pygraphviz"


### PR DESCRIPTION
We are using PEP 639 for our project description which added in setuptools 77 so bumping up the min version at build time.