### PR TITLE
CI: Rm fedora/macports testing workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,40 +48,6 @@ jobs:
         run: |
           pytest --doctest-modules --durations=10 --pyargs pygraphviz
 
-  fedora:
-    strategy:
-      matrix:
-        release:
-          - 40
-          - 41
-
-    runs-on: Ubuntu-latest
-    container: "fedora:${{ matrix.release }}"
-
-    steps:
-      - name: Checkout pygraphviz
-        uses: actions/checkout@v6
-
-      - name: Install graphviz
-        run: sudo dnf install -y graphviz graphviz-devel
-
-      - name: Install Python developer tools
-        run: sudo dnf install -y python3-devel
-
-      - name: Install gcc
-        run: sudo dnf install -y gcc
-
-      - name: Install packages
-        run: |
-          pip install --upgrade pip
-          pip install -r requirements/test.txt
-          pip install .
-          pip list
-
-      - name: Test pygraphviz
-        run: |
-          pytest --doctest-modules --durations=10 --pyargs pygraphviz
-
   brew:
     runs-on: macOS-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,46 +115,6 @@ jobs:
         run: |
           pytest --doctest-modules --durations=10 --pyargs pygraphviz
 
-  macports:
-    runs-on: macOS-latest
-
-    strategy:
-      matrix:
-        python-version: ["3.12", "3.13", "3.14"]
-
-    steps:
-      - name: Checkout pygraphviz
-        uses: actions/checkout@v6
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Download macports pkg
-        run: wget https://github.com/macports/macports-base/releases/download/v2.11.6/MacPorts-2.11.6-15-Sequoia.pkg
-
-      - name: Install macports
-        run: sudo installer -pkg MacPorts-2.11.6-15-Sequoia.pkg -target /
-
-      - name: Install graphviz
-        run: sudo /opt/local/bin/port install graphviz
-
-      - name: Install packages
-        run: |
-          pip install --upgrade pip setuptools
-          pip install -r requirements/test.txt
-          pip install --config-settings="--global-option=build_ext" \
-                      --config-settings="--global-option=-I/opt/local/include/" \
-                      --config-settings="--global-option=-L/opt/local/lib/" \
-                      .
-          pip list
-
-      - name: Test pygraphviz
-        run: |
-          export PATH=/opt/local/bin:/opt/local/sbin:$PATH
-          pytest --doctest-modules --durations=10 --pyargs pygraphviz
-
   windows:
     runs-on: windows-latest
 


### PR DESCRIPTION
With cibuildwheel now handling the packaging of graphviz dependencies, these jobs are less relevant. The majority of users will be getting binary wheels for their systems with no external graphviz dependencies.

I've left the ubuntu, macos (+brew), and windows testing workflows so we still have coverage of the "build from source+test" pattern (in addition to the testing done in the cibuildwheel workflows).