### PR TITLE
TST: Add tests for `tred` method

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -1421,13 +1421,29 @@ class AGraph:
     def tred(self, args="", copy=False):
         """Transitive reduction of graph.  Modifies existing graph.
 
-        To create a new graph use
+        See the graphviz "tred" program for details of the algorithm.
+
+        Examples
+        --------
+        tred modifies the graph in-place by default:
 
         >>> import pygraphviz as pgv
         >>> A = pgv.AGraph(directed=True)
-        >>> B = A.tred(copy=True)  # doctest: +SKIP
+        >>> A.add_edges_from([(0, 1), (1, 2), (0, 2)])
+        >>> B = A.tred()
+        >>> A.edges()
+        [('0', '1'), ('1', '2')]
+        >>> A.edges() == B.edges()
+        True
 
-        See the graphviz "tred" program for details of the algorithm.
+        To create a new graph use ``copy=True``
+
+        >>> import pygraphviz as pgv
+        >>> A = pgv.AGraph(directed=True)
+        >>> A.add_edges_from([(0, 1), (1, 2), (0, 2)])
+        >>> B = A.tred(copy=True)
+        >>> B.edges()
+        [('0', '1'), ('1', '2')]
         """
         if not self.directed:
             raise TypeError("tred requires a directed graph")

--- a/pygraphviz/tests/test_graph.py
+++ b/pygraphviz/tests/test_graph.py
@@ -1,8 +1,46 @@
+import warnings
 import pytest
 import unittest
 import pygraphviz as pgv
 
 stringify = pgv.testing.stringify
+
+
+def test_tred():
+    A = pgv.AGraph(directed=True)
+    A.add_edges_from([(0, 1), (1, 2), (0, 2)])
+    # copy=False by default
+    B = A.tred()
+    assert A.edges() == B.edges() == [("0", "1"), ("1", "2")]
+
+
+def test_tred_copy():
+    A = pgv.AGraph(directed=True)
+    A.add_edges_from([(0, 1), (1, 2), (0, 2)])
+    # With copy=True, original graph should remain unchanged
+    B = A.tred(copy=True)
+    # NOTE: edges may be reordered, but should remain unaltered
+    assert set(A.edges()) == {("0", "1"), ("1", "2"), ("0", "2")}
+    assert B.edges() == [("0", "1"), ("1", "2")]
+
+
+def test_tred_undirected():
+    A = pgv.AGraph()
+    A.add_edges_from([(0, 1), (1, 2), (0, 2)])
+    with pytest.raises(TypeError, match="tred requires a directed graph"):
+        A.tred()
+
+
+def test_tred_cycle():
+    """RuntimeWarning raised when cycle detected."""
+    A = pgv.AGraph(directed=True)
+    A.add_edges_from([(0, 1), (1, 2), (2, 0)])  # Directed 3-cycle
+    with warnings.catch_warnings(record=True, category=RuntimeWarning) as rec:
+        A.tred()
+    # No transitive reduction possible on 3-cycle
+    assert A.edges() == [("0", "1"), ("1", "2"), ("2", "0")]
+    assert len(rec) == 1  # Expect 1 RuntimeWarning
+    assert "transitive reduction not unique" in str(rec[0].message)
 
 
 class TestGraph(unittest.TestCase):


### PR DESCRIPTION
`tred` is one of the functions that still requires the CLI of graphviz, so this doubles as a packaging test for the path-munging approach used for the pygraphviz 2.0 wheels.

Loosely inspired by @dschult 's review in gh-614 which made me realize I'm not sure an explicit test of the CLI-based functionality exists in the test suite. Prior to pygraphviz2.0 there was no distinction between "library-based" and "cli-based" functions, as graphviz was required to be installed on the user's system no matter what.