### PR TITLE
CI: See what happens when freethreading enabled.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14", "3.14t"]
 
     steps:
       - name: Checkout pygraphviz
@@ -45,15 +45,20 @@ jobs:
           pip list
 
       - name: Test pygraphviz
+        if: ${{ matrix.python-version }} != '3.14t'
         run: |
           pytest --doctest-modules --durations=10 --pyargs pygraphviz
+      - name: Test pygraphviz freethreaded
+        if: ${{ matrix.python-version }} == '3.14t'
+        run: |
+          PYTHON_GIL=0 pytest --doctest-modules --durations=10 --pyargs pygraphviz
 
   brew:
     runs-on: macOS-latest
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14", "3.14t"]
 
     steps:
       - name: Checkout pygraphviz
@@ -78,15 +83,20 @@ jobs:
           pip list
 
       - name: Test pygraphviz
+        if: ${{ matrix.python-version }} != '3.14t'
         run: |
           pytest --doctest-modules --durations=10 --pyargs pygraphviz
+      - name: Test pygraphviz freethreaded
+        if: ${{ matrix.python-version }} == '3.14t'
+        run: |
+          PYTHON_GIL=0 pytest --doctest-modules --durations=10 --pyargs pygraphviz
 
   windows:
     runs-on: windows-latest
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14", "3.14t"]
 
     steps:
       - name: Checkout pygraphviz
@@ -118,8 +128,16 @@ jobs:
       - name: List
         run: Get-ChildItem "$($env:WIN_GRAPHVIZ_DIR)\bin"
 
-      # Set PY_IGNORE_IMPORTMISMATCH b/c otherwise --doctest-modules is confused.
+      #      # Set PY_IGNORE_IMPORTMISMATCH b/c otherwise --doctest-modules is confused.
+      #      - name: Test pygraphviz
+      #        run: |
+      #          [Environment]::SetEnvironmentVariable("PY_IGNORE_IMPORTMISMATCH", 1)
+      #          pytest --doctest-modules --durations=10 --pyargs pygraphviz
       - name: Test pygraphviz
+        if: ${{ matrix.python-version }} != '3.14t'
         run: |
-          [Environment]::SetEnvironmentVariable("PY_IGNORE_IMPORTMISMATCH", 1)
           pytest --doctest-modules --durations=10 --pyargs pygraphviz
+      - name: Test pygraphviz freethreaded
+        if: ${{ matrix.python-version }} == '3.14t'
+        run: |
+          PYTHON_GIL=0 pytest --doctest-modules --durations=10 --pyargs pygraphviz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,11 +128,6 @@ jobs:
       - name: List
         run: Get-ChildItem "$($env:WIN_GRAPHVIZ_DIR)\bin"
 
-      #      # Set PY_IGNORE_IMPORTMISMATCH b/c otherwise --doctest-modules is confused.
-      #      - name: Test pygraphviz
-      #        run: |
-      #          [Environment]::SetEnvironmentVariable("PY_IGNORE_IMPORTMISMATCH", 1)
-      #          pytest --doctest-modules --durations=10 --pyargs pygraphviz
       - name: Test pygraphviz
         if: ${{ matrix.python-version != '3.14t' }}
         run: |
@@ -140,4 +135,5 @@ jobs:
       - name: Test pygraphviz freethreaded
         if: ${{ matrix.python-version == '3.14t' }}
         run: |
-          PYTHON_GIL=0 pytest --doctest-modules --durations=10 --pyargs pygraphviz
+          [Environment]::SetEnvironmentVariable("PYTHON_GIL", 0)
+          pytest --doctest-modules --durations=10 --pyargs pygraphviz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,11 +45,11 @@ jobs:
           pip list
 
       - name: Test pygraphviz
-        if: ${{ matrix.python-version }} != '3.14t'
+        if: ${{ matrix.python-version != '3.14t' }}
         run: |
           pytest --doctest-modules --durations=10 --pyargs pygraphviz
       - name: Test pygraphviz freethreaded
-        if: ${{ matrix.python-version }} == '3.14t'
+        if: ${{ matrix.python-version  == '3.14t' }}
         run: |
           PYTHON_GIL=0 pytest --doctest-modules --durations=10 --pyargs pygraphviz
 
@@ -83,11 +83,11 @@ jobs:
           pip list
 
       - name: Test pygraphviz
-        if: ${{ matrix.python-version }} != '3.14t'
+        if: ${{ matrix.python-version != '3.14t' }}
         run: |
           pytest --doctest-modules --durations=10 --pyargs pygraphviz
       - name: Test pygraphviz freethreaded
-        if: ${{ matrix.python-version }} == '3.14t'
+        if: ${{ matrix.python-version == '3.14t' }}
         run: |
           PYTHON_GIL=0 pytest --doctest-modules --durations=10 --pyargs pygraphviz
 
@@ -134,10 +134,10 @@ jobs:
       #          [Environment]::SetEnvironmentVariable("PY_IGNORE_IMPORTMISMATCH", 1)
       #          pytest --doctest-modules --durations=10 --pyargs pygraphviz
       - name: Test pygraphviz
-        if: ${{ matrix.python-version }} != '3.14t'
+        if: ${{ matrix.python-version != '3.14t' }}
         run: |
           pytest --doctest-modules --durations=10 --pyargs pygraphviz
       - name: Test pygraphviz freethreaded
-        if: ${{ matrix.python-version }} == '3.14t'
+        if: ${{ matrix.python-version == '3.14t' }}
         run: |
           PYTHON_GIL=0 pytest --doctest-modules --durations=10 --pyargs pygraphviz


### PR DESCRIPTION
Adds 3.14t to the Python testing matrix to see what happens with freethreaded builds.

pygraphviz does not explicitly support freethreaded Python, so the expectation is python will fallback to the GIL when pygraphviz is imported (this is what happens). This PR *forces* the GIL to stay off just to see what happens.