### PR TITLE
TST: Assert hex colors don't cause runtime warnings.

### DIFF
--- a/pygraphviz/tests/test_drawing.py
+++ b/pygraphviz/tests/test_drawing.py
@@ -1,5 +1,50 @@
+import warnings
 import pygraphviz as pgv
 import pytest
+
+
+def test_drawing_hex_colors(tmp_path):
+    """Ensure hex colors are supported without warnings - see gh-351."""
+    # fmt: off
+    dotstr = """
+        digraph dag {
+        ratio=fill
+        node [style=filled,color="#444444",fillcolor="#ffed6f"]
+        edge [arrowhead=normal,arrowsize=1.0]
+
+        "ID0000001" [shape=ellipse,color="#000000",fillcolor="#1b9e77",label="preprocess\nID0000001"]
+        "ID0000002" [shape=ellipse,color="#000000",fillcolor="#d95f02",label="findrange\nID0000002"]
+        "ID0000003" [shape=ellipse,color="#000000",fillcolor="#d95f02",label="findrange\nID0000003"]
+        "ID0000004" [shape=ellipse,color="#000000",fillcolor="#7570b3",label="analyze\nID0000004"]
+        "f.a" [shape=rect,color="#000000",fillcolor="#ffed6f",label="f.a"]
+        "f.b1" [shape=rect,color="#000000",fillcolor="#ffed6f",label="f.b1"]
+        "f.b2" [shape=rect,color="#000000",fillcolor="#ffed6f",label="f.b2"]
+        "f.c1" [shape=rect,color="#000000",fillcolor="#ffed6f",label="f.c1"]
+        "f.c2" [shape=rect,color="#000000",fillcolor="#ffed6f",label="f.c2"]
+        "f.d" [shape=rect,color="#000000",fillcolor="#ffed6f",label="f.d"]
+        "ID0000001" -> "f.b1" [color="#000000"]
+        "ID0000001" -> "f.b2" [color="#000000"]
+        "ID0000001" -> "ID0000003" [color="#000000"]
+        "ID0000001" -> "ID0000002" [color="#000000"]
+        "ID0000002" -> "f.c1" [color="#000000"]
+        "ID0000002" -> "ID0000004" [color="#000000"]
+        "ID0000003" -> "f.c2" [color="#000000"]
+        "ID0000003" -> "ID0000004" [color="#000000"]
+        "ID0000004" -> "f.d" [color="#000000"]
+        "f.a" -> "ID0000001" [color="#000000"]
+        "f.b1" -> "ID0000002" [color="#000000"]
+        "f.b2" -> "ID0000003" [color="#000000"]
+        "f.c1" -> "ID0000004" [color="#000000"]
+        "f.c2" -> "ID0000004" [color="#000000"]
+    }
+    """
+    # fmt: on
+    A = pgv.AGraph()
+    A.from_string(dotstr)
+    with warnings.catch_warnings(record=True, category=RuntimeWarning) as rec:
+        A.layout("dot")
+        A.draw(str(tmp_path / "img.png"))
+    assert len(rec) == 0
 
 
 def test_drawing_error():


### PR DESCRIPTION
Closes gh-351 , or at least adds a regression test to show that gh-351 is no longer an issue as of pygraphviz 2.0