### PR TITLE
TST: Add regression test for gh-171.

### DIFF
--- a/pygraphviz/tests/test_readwrite.py
+++ b/pygraphviz/tests/test_readwrite.py
@@ -1,6 +1,9 @@
 import pygraphviz as pgv
 
+graphviz_major_version = int(pgv.__graphviz_version__.split(".")[0])
 
+
+@pytest.mark.skipif(graphviz_major_version < 13, reason="Graphviz version too old")
 def test_multiple_reads_same_source_trailing_character(tmp_path):
     """Ensure multiple reads from the same text file with an unexpected trailing
     character don't cause agread fails. See gh-171."""

--- a/pygraphviz/tests/test_readwrite.py
+++ b/pygraphviz/tests/test_readwrite.py
@@ -1,6 +1,21 @@
 import pygraphviz as pgv
 
 
+def test_multiple_reads_same_source_trailing_character(tmp_path):
+    """Ensure multiple reads from the same text file with an unexpected trailing
+    character don't cause agread fails. See gh-171."""
+    fpath = tmp_path / "hello.gv.txt"
+    # Original bug was in the read-from-file code path
+    with open(fpath, "w") as fh:
+        fh.write('digraph G {Hello->World}"')  # note the trailing "
+
+    # Smoke test: sequential reads from the same file via the AGraph constructor
+    # should not raise ValueError/DotError
+    A = pgv.AGraph(str(fpath))
+    B = pgv.AGraph(str(fpath))
+    assert A.to_string() == B.to_string()
+
+
 def test_readwrite(tmp_path):
     A = pgv.AGraph(name="test graph")
     A.add_path([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])

--- a/pygraphviz/tests/test_readwrite.py
+++ b/pygraphviz/tests/test_readwrite.py
@@ -1,3 +1,4 @@
+import pytest
 import pygraphviz as pgv
 
 graphviz_major_version = int(pgv.__graphviz_version__.split(".")[0])


### PR DESCRIPTION
Turns the example for the bug ID'ed in gh-171 into a unit test.

I was unable to produce locally, so hopefully everything is fixed. Let's see if CI is green on all platforms.