### PR TITLE
ENH: Export version info from wrapped graphviz

### DIFF
--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -12,6 +12,13 @@ Import PyGraphviz with
 
 >>> import pygraphviz as pgv
 
+PyGraphviz wraps `graphviz <https://graphviz.org>`_ providing a Python interface
+to graphviz's functionality.
+Information about the version of graphviz that is wrapped by pygraphviz can be
+found with
+
+>>> pgv.__graphviz_version__
+
 Graphs
 ------
 

--- a/pygraphviz/__init__.py
+++ b/pygraphviz/__init__.py
@@ -26,10 +26,16 @@ if sys.version_info >= (3, 8, 0) and sys.platform == "win32":
             os.add_dll_directory(path)
 
 
-from ._graphviz import GRAPHVIZ_VERSION
+from ._graphviz import (
+    GRAPHVIZ_MAJOR_VERSION,
+    GRAPHVIZ_MINOR_VERSION,
+    GRAPHVIZ_PATCH_VERSION,
+)
 
 __version__ = "2.0rc2"
-__graphviz_version__ = GRAPHVIZ_VERSION
+__graphviz_version__ = (
+    f"{GRAPHVIZ_MAJOR_VERSION}.{GRAPHVIZ_MINOR_VERSION}.{GRAPHVIZ_PATCH_VERSION}"
+)
 
 from .agraph import AGraph, Attribute, DotError, Edge, ItemAttribute, Node
 

--- a/pygraphviz/__init__.py
+++ b/pygraphviz/__init__.py
@@ -26,7 +26,10 @@ if sys.version_info >= (3, 8, 0) and sys.platform == "win32":
             os.add_dll_directory(path)
 
 
+from ._graphviz import GRAPHVIZ_VERSION
+
 __version__ = "2.0rc2"
+__graphviz_version__ = GRAPHVIZ_VERSION
 
 from .agraph import AGraph, Attribute, DotError, Edge, ItemAttribute, Node
 

--- a/pygraphviz/graphviz.i
+++ b/pygraphviz/graphviz.i
@@ -11,7 +11,9 @@
 #include <string.h>
 %}
 
-#define GRAPHVIZ_VERSION GRAPHVIZ_VERSION_MAJOR
+#define GRAPHVIZ_MAJOR_VERSION GRAPHVIZ_VERSION_MAJOR
+#define GRAPHVIZ_MINOR_VERSION GRAPHVIZ_VERSION_MINOR
+#define GRAPHVIZ_PATCH_VERSION GRAPHVIZ_VERSION_PATCH
 
 %typemap(in) FILE* input_file (int fd, PyObject *mode_obj, PyObject *mode_byte_obj, char *mode) {
     if ($input == Py_None) { $1 = NULL; }

--- a/pygraphviz/graphviz.i
+++ b/pygraphviz/graphviz.i
@@ -11,6 +11,8 @@
 #include <string.h>
 %}
 
+#define GRAPHVIZ_VERSION GRAPHVIZ_VERSION_MAJOR
+
 %typemap(in) FILE* input_file (int fd, PyObject *mode_obj, PyObject *mode_byte_obj, char *mode) {
     if ($input == Py_None) { $1 = NULL; }
     else {

--- a/pygraphviz/graphviz.py
+++ b/pygraphviz/graphviz.py
@@ -58,7 +58,9 @@ class _SwigNonDynamicMeta(type):
     __setattr__ = _swig_setattr_nondynamic_class_variable(type.__setattr__)
 
 
-GRAPHVIZ_VERSION = _graphviz.GRAPHVIZ_VERSION
+GRAPHVIZ_MAJOR_VERSION = _graphviz.GRAPHVIZ_MAJOR_VERSION
+GRAPHVIZ_MINOR_VERSION = _graphviz.GRAPHVIZ_MINOR_VERSION
+GRAPHVIZ_PATCH_VERSION = _graphviz.GRAPHVIZ_PATCH_VERSION
 
 def agopen(name, kind, disc):
     return _graphviz.agopen(name, kind, disc)

--- a/pygraphviz/graphviz.py
+++ b/pygraphviz/graphviz.py
@@ -58,6 +58,7 @@ class _SwigNonDynamicMeta(type):
     __setattr__ = _swig_setattr_nondynamic_class_variable(type.__setattr__)
 
 
+GRAPHVIZ_VERSION = _graphviz.GRAPHVIZ_VERSION
 
 def agopen(name, kind, disc):
     return _graphviz.agopen(name, kind, disc)

--- a/pygraphviz/tests/test_pygraphviz.py
+++ b/pygraphviz/tests/test_pygraphviz.py
@@ -1,0 +1,13 @@
+import pytest
+
+import pygraphviz as pgv
+
+
+def test_graphviz_version():
+    """Test to ensure package exports the __graphviz_version__ attribute, which
+    holds the version info for the packaged graphviz version."""
+    # Smoke test - the following lines will fail if e.g. __graphviz_version__
+    # is not present or the version string takes an unexpected form
+    graphviz_version = pgv.__graphviz_version__
+    vmaj, vmin, vpatch = graphviz_version.split(".")
+    assert int(vmaj) >= 2

--- a/setup.py
+++ b/setup.py
@@ -23,11 +23,19 @@ if __name__ == "__main__":
             "Graphviz must be installed to build pygraphviz from source.\n\n"
         ) from e
 
-    vm = re.match(r"dot - graphviz version (\d+)", version_str.decode())
-    graphviz_major_version = int(vm.string[: vm.end()].split(" ")[-1])
-    print(f"Detected Graphviz version {graphviz_major_version}")
+    vm = re.match(r"dot - graphviz version \d+(\.\d+)+", version_str.decode())
+    graphviz_version = vm.string[: vm.end()].split(" ")[-1]
+    print(f"Detected Graphviz version {graphviz_version}")
+    vmaj, vmin, vpatch = graphviz_version.split(".")
+    graphviz_major_version = int(vmaj)
+    graphviz_minor_version = int(vmin)
+    graphviz_patch_version = int(vpatch)
     # Pass version info into swig build
-    swig_options = [f"-DGRAPHVIZ_VERSION_MAJOR={graphviz_major_version}"]
+    swig_options = [
+        f"-DGRAPHVIZ_VERSION_MAJOR={graphviz_major_version}",
+        f"-DGRAPHVIZ_VERSION_MINOR={graphviz_minor_version}",
+        f"-DGRAPHVIZ_VERSION_PATCH={graphviz_patch_version}",
+    ]
 
     define_macros = [("SWIG_PYTHON_STRICT_BYTE_CHAR", None)]
     if WINDOWS:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,10 @@ if __name__ == "__main__":
     vm = re.match(r"dot - graphviz version \d+(\.\d+)+", version_str.decode())
     graphviz_version = vm.string[: vm.end()].split(" ")[-1]
     print(f"Detected Graphviz version {graphviz_version}")
+
     vmaj, vmin, vpatch = graphviz_version.split(".")
+    # NOTE: int() is not strictly necessary, but used as implicit validation of
+    # version string
     graphviz_major_version = int(vmaj)
     graphviz_minor_version = int(vmin)
     graphviz_patch_version = int(vpatch)


### PR DESCRIPTION
Now that graphviz is packaged within pygraphviz itself, it would be good to provide API so that users can check the underlying graphviz version.

Inspired by #620, to which we'd like to add conditional test skips for older versions of graphviz (but there's currently no way to assess the from pygraphviz itself).

Re: implementation - I'm no swig expert so I just arbitrarily picked a pattern from the [SWIG-basics docs](https://www.swig.org/Doc3.0/SWIG.html#SWIG_nn9). Of course, this involves pre-parsing the version string into ints for major, minor and patch versions; passing them in via SWIG CLI macros at build time; then reconstructing the version string at import time. There's probably a more elegant way to do this - SWIG folks feel free to weigh in!

Another decision I made was to handle all the version comparisons manually rather than relying on a nicer interface like `packaging.version`. My reasoning was to keep the build dep footprint to an absolute minimum. If we decide that adding a build-time dependency on `packaging` is acceptable, we can clean some of this up. I'd vote to hold that discussion off for a follow-up PR though!

Finally, there's the API for the graphviz version info itself. I arbitrarily chose a dunder-pattern `__graphviz_version__` to a) match the familiar `__version__` pattern and b) prevent accidental discover of the hidden `_graphviz` module if users happen to do something like `pgv._g<tab>` while searching for graphviz version info. If others prefer a different pattern that's fine with me!