### PR TITLE
DOC: Make tutorial executable, run as part of doc build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ doc/build
 doc/source/static/examples/*
 doc/source/reference/generated/*
 doc/source/examples/*
+doc/source/file.*
 
 # Generated when 'python setup_egg.py'
 pygraphviz.egg-info/

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -68,6 +68,12 @@ add_module_names = False
 pygments_style = "sphinx"
 
 
+def setup(app):
+    # Workaround to prevent duplicate file warnings from sphinx due to having
+    # both myst-nb and sphinx-gallery generating executable files
+    app.registry.source_suffix.pop(".ipynb")
+
+
 # Options for HTML output
 # -----------------------
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,6 +22,7 @@ extensions = [
     "sphinx.ext.imgconverter",
     "sphinx_gallery.gen_gallery",
     "numpydoc",
+    "myst_nb",
 ]
 
 # General substitutions.

--- a/doc/source/tutorial.md
+++ b/doc/source/tutorial.md
@@ -1,122 +1,154 @@
-Tutorial
-========
+# Tutorial
 
-The API is very similar to that of NetworkX.  Much of the
-`NetworkX tutorial <https://networkx.org/documentation/latest/tutorial.html>`_
+The API is very similar to that of NetworkX. Much of the
+[NetworkX tutorial](https://networkx.org/documentation/latest/tutorial.html)
 is applicable to PyGraphviz.
 
-Start-up
---------
+## Start-up
 
 Import PyGraphviz with
 
+```pycon
 >>> import pygraphviz as pgv
+```
 
-PyGraphviz wraps `graphviz <https://graphviz.org>`_ providing a Python interface
+PyGraphviz wraps [graphviz](https://graphviz.org) providing a Python interface
 to graphviz's functionality.
 Information about the version of graphviz that is wrapped by pygraphviz can be
 found with
 
+```pycon
 >>> pgv.__graphviz_version__
+```
 
-Graphs
-------
+## Graphs
 
 To make an empty pygraphviz graph use the AGraph class:
 
+```pycon
 >>> G = pgv.AGraph()
+```
 
 You can use the strict and directed keywords to control what type of
-graph you want.  The default is to create a strict graph
-(no parallel edges or self-loops).  To create a digraph with possible
+graph you want. The default is to create a strict graph
+(no parallel edges or self-loops). To create a digraph with possible
 parallel edges and self-loops use
 
+```pycon
 >>> G = pgv.AGraph(strict=False, directed=True)
+```
 
 You may specify a dot format file to be read on initialization:
 
+```pycon
 >>> G = pgv.AGraph("Petersen.dot")  # doctest: +SKIP
+```
 
 Other options for initializing a graph are using a string,
 
+```pycon
 >>> G = pgv.AGraph("graph {1 - 2}")
+```
 
 using a dict of dicts,
 
+```pycon
 >>> d = {"1": {"2": None}, "2": {"1": None, "3": None}, "3": {"2": None}}
 >>> A = pgv.AGraph(d)
+```
 
 or using a SWIG pointer to the AGraph datastructure,
 
+```pycon
 >>> h = A.handle
 >>> C = pgv.AGraph(h)
+```
 
-
-Nodes, and edges
-----------------
+## Nodes, and edges
 
 Nodes and edges can be added one at a time
 
+```pycon
 >>> G.add_node("a")  # adds node 'a'
 >>> G.add_edge("b", "c")  # adds edge 'b'-'c' (and also nodes 'b', 'c')
+```
 
 or from lists or containers.
 
+```pycon
 >>> nodelist = ["f", "g", "h"]
 >>> G.add_nodes_from(nodelist)
+```
 
 If the node is not a string an attempt will be made to convert it
 to a string
 
+```pycon
 >>> G.add_node(1)  # adds node '1'
+```
 
-
-Attributes
-----------
+## Attributes
 
 To set the default attributes for graphs, nodes, and edges use
 the graph_attr, node_attr, and edge_attr dictionaries
 
+```pycon
 >>> G.graph_attr["label"] = "Name of graph"
 >>> G.node_attr["shape"] = "circle"
 >>> G.edge_attr["color"] = "red"
+```
 
 Graph attributes can be set when initializing the graph
 
+```pycon
 >>> G = pgv.AGraph(ranksep="0.1")
+```
 
 Attributes can be added when adding nodes or edges,
 
+```pycon
 >>> G.add_node(1, color="red")
 >>> G.add_edge("b", "c", color="blue")
+```
 
 or through the node or edge attr dictionaries,
 
+```pycon
 >>> n = G.get_node(1)
 >>> n.attr["shape"] = "box"
+```
 
-
+```pycon
 >>> e = G.get_edge("b", "c")
 >>> e.attr["color"] = "green"
+```
 
-Layout and Drawing
-------------------
+## Layout and Drawing
+
 Pygraphviz provides several methods for layout and drawing of graphs.
 
 To store and print the graph in dot format as a Python string use
 
+```pycon
 >>> s = G.string()
+```
 
 To write to a file use
 
+```pycon
 >>> G.write("file.dot")
+```
 
 To add positions to the nodes with a Graphviz layout algorithm
 
+```pycon
 >>> G.layout()  # default to neato
 >>> G.layout(prog="dot")  # use dot
+```
 
 To render the graph to an image
 
+```pycon
 >>> G.draw("file.png")  # write previously positioned graph to PNG file
 >>> G.draw("file.ps", prog="circo")  # use circo to position, write PS file
+```

--- a/doc/source/tutorial.md
+++ b/doc/source/tutorial.md
@@ -1,3 +1,16 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.13.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
 # Tutorial
 
 The API is very similar to that of NetworkX. Much of the
@@ -8,8 +21,8 @@ is applicable to PyGraphviz.
 
 Import PyGraphviz with
 
-```pycon
->>> import pygraphviz as pgv
+```{code-cell}
+import pygraphviz as pgv
 ```
 
 PyGraphviz wraps [graphviz](https://graphviz.org) providing a Python interface
@@ -17,16 +30,17 @@ to graphviz's functionality.
 Information about the version of graphviz that is wrapped by pygraphviz can be
 found with
 
-```pycon
->>> pgv.__graphviz_version__
+```{code-cell}
+pgv.__graphviz_version__
 ```
 
 ## Graphs
 
 To make an empty pygraphviz graph use the AGraph class:
 
-```pycon
->>> G = pgv.AGraph()
+```{code-cell}
+G = pgv.AGraph()
+print(G)
 ```
 
 You can use the strict and directed keywords to control what type of
@@ -34,57 +48,64 @@ graph you want. The default is to create a strict graph
 (no parallel edges or self-loops). To create a digraph with possible
 parallel edges and self-loops use
 
-```pycon
->>> G = pgv.AGraph(strict=False, directed=True)
+```{code-cell}
+G = pgv.AGraph(strict=False, directed=True)
+print(G)
 ```
 
 You may specify a dot format file to be read on initialization:
 
-```pycon
->>> G = pgv.AGraph("Petersen.dot")  # doctest: +SKIP
+```python
+G = pgv.AGraph("Petersen.dot")
 ```
 
 Other options for initializing a graph are using a string,
 
-```pycon
->>> G = pgv.AGraph("graph {1 - 2}")
+```{code-cell}
+G = pgv.AGraph("graph {1 -- 2;}")
+print(G)
 ```
 
 using a dict of dicts,
 
-```pycon
->>> d = {"1": {"2": None}, "2": {"1": None, "3": None}, "3": {"2": None}}
->>> A = pgv.AGraph(d)
+```{code-cell}
+d = {"1": {"2": None}, "2": {"1": None, "3": None}, "3": {"2": None}}
+A = pgv.AGraph(d)
+print(A)
 ```
 
 or using a SWIG pointer to the AGraph datastructure,
 
-```pycon
->>> h = A.handle
->>> C = pgv.AGraph(h)
+```python
+h = A.handle
+C = pgv.AGraph(h)
 ```
 
 ## Nodes, and edges
 
 Nodes and edges can be added one at a time
 
-```pycon
->>> G.add_node("a")  # adds node 'a'
->>> G.add_edge("b", "c")  # adds edge 'b'-'c' (and also nodes 'b', 'c')
+```{code-cell}
+G = pgv.AGraph()
+G.add_node("a")  # adds node 'a'
+G.add_edge("b", "c")  # adds edge 'b'-'c' (and also nodes 'b', 'c')
+print(G)
 ```
 
 or from lists or containers.
 
-```pycon
->>> nodelist = ["f", "g", "h"]
->>> G.add_nodes_from(nodelist)
+```{code-cell}
+nodelist = ["f", "g", "h"]
+G.add_nodes_from(nodelist)
+print(G)
 ```
 
 If the node is not a string an attempt will be made to convert it
 to a string
 
-```pycon
->>> G.add_node(1)  # adds node '1'
+```{code-cell}
+G.add_node(1)  # adds node '1'
+G.nodes()
 ```
 
 ## Attributes
@@ -92,35 +113,38 @@ to a string
 To set the default attributes for graphs, nodes, and edges use
 the graph_attr, node_attr, and edge_attr dictionaries
 
-```pycon
->>> G.graph_attr["label"] = "Name of graph"
->>> G.node_attr["shape"] = "circle"
->>> G.edge_attr["color"] = "red"
+```{code-cell}
+G = pgv.AGraph()
+G.graph_attr["label"] = "Name of graph"
+G.node_attr["shape"] = "circle"
+G.edge_attr["color"] = "red"
+G.add_edge("A", "B")
+print(G)
 ```
 
 Graph attributes can be set when initializing the graph
 
-```pycon
->>> G = pgv.AGraph(ranksep="0.1")
+```{code-cell}
+G = pgv.AGraph(ranksep="0.1")
 ```
 
 Attributes can be added when adding nodes or edges,
 
-```pycon
->>> G.add_node(1, color="red")
->>> G.add_edge("b", "c", color="blue")
+```{code-cell}
+G.add_node(1, color="red")
+G.add_edge("b", "c", color="blue")
+print(G)
 ```
 
 or through the node or edge attr dictionaries,
 
-```pycon
->>> n = G.get_node(1)
->>> n.attr["shape"] = "box"
-```
+```{code-cell}
+n = G.get_node(1)
+n.attr["shape"] = "box"
 
-```pycon
->>> e = G.get_edge("b", "c")
->>> e.attr["color"] = "green"
+e = G.get_edge("b", "c")
+e.attr["color"] = "green"
+print(G)
 ```
 
 ## Layout and Drawing
@@ -129,26 +153,26 @@ Pygraphviz provides several methods for layout and drawing of graphs.
 
 To store and print the graph in dot format as a Python string use
 
-```pycon
->>> s = G.string()
+```{code-cell}
+G.string()
 ```
 
 To write to a file use
 
 ```pycon
->>> G.write("file.dot")
+G.write("file.dot")
 ```
 
 To add positions to the nodes with a Graphviz layout algorithm
 
 ```pycon
->>> G.layout()  # default to neato
->>> G.layout(prog="dot")  # use dot
+G.layout()  # default to neato
+G.layout(prog="dot")  # use dot
 ```
 
 To render the graph to an image
 
 ```pycon
->>> G.draw("file.png")  # write previously positioned graph to PNG file
->>> G.draw("file.ps", prog="circo")  # use circo to position, write PS file
+G.draw("file.png")  # write previously positioned graph to PNG file
+G.draw("file.ps", prog="circo")  # use circo to position, write PS file
 ```

--- a/doc/source/tutorial.md
+++ b/doc/source/tutorial.md
@@ -154,25 +154,55 @@ Pygraphviz provides several methods for layout and drawing of graphs.
 To store and print the graph in dot format as a Python string use
 
 ```{code-cell}
-G.string()
+s = G.string()
+print(s)
 ```
 
 To write to a file use
 
-```pycon
+```{code-cell}
+# Test round-tripping graph data to/from file
 G.write("file.dot")
+
+with open("file.dot") as fh:
+    H = pgv.AGraph(fh.read())
+
+H.string() == s
 ```
 
 To add positions to the nodes with a Graphviz layout algorithm
 
-```pycon
+```{code-cell}
 G.layout()  # default to neato
+print(G)
+```
+
+```{code-cell}
 G.layout(prog="dot")  # use dot
+print(G)
 ```
 
 To render the graph to an image
 
-```pycon
+```{code-cell}
 G.draw("file.png")  # write previously positioned graph to PNG file
-G.draw("file.ps", prog="circo")  # use circo to position, write PS file
+```
+
+```{figure} file.png
+
+```
+
+```python
+# Use `circo` layout to position, write to PostScript file for e.g. embedding
+# in a LaTeX document
+G.draw("file.ps", prog="circo")
+```
+
+```{code-cell}
+# Or render directly to an image format
+G.draw("file.svg", prog="circo")
+```
+
+```{figure} file.svg
+
 ```

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -3,3 +3,4 @@ pydata-sphinx-theme>=0.15.4
 sphinx-gallery>=0.17
 matplotlib>=3.9
 numpydoc>=1.8
+myst-nb


### PR DESCRIPTION
This PR proposes to incorporate the `myst-nb` extension, reformat the tutorial as a [markdown-based jupyter notebook](https://myst-nb.readthedocs.io/en/v0.9.1/use/markdown.html), and ensure that the tutorial is executed at doc-build time.

This essentially a pygraphviz-version of networkx/networkx#7237 (though simpler, since there was no existing execution engine to replace).

The primary benefit here is ensuring that the tutorial documentation is actually correct - activating the execution caught [one cell that actually raises an exception due to invalid dot format](https://github.com/pygraphviz/pygraphviz/blob/d8d49391b0109c385ffb413d86c8989c5957d4d1/doc/source/tutorial.rst?plain=1#L42). It also adds another layer of integration testing to catch exceptions/warnings/deprecations from e.g. changes in graphviz.

Finally - there is a relatively simple pattern to adopt to actually show the drawing results in the tutorial, which is a nice little enhancement IMO.

I used `rst2myst` to convert the tutorial to MyST format; unfortunately that doesn't do much to preserve diffs. I think there's a way I could improve this with some manually patch munging - LMK if you'd like me to try!