### PR TITLE
BUG: Use "nop2" instead of "neato -n2" for rendering with pre-computed positions

### DIFF
--- a/examples/plot_miles.py
+++ b/examples/plot_miles.py
@@ -93,5 +93,5 @@ if __name__ == "__main__":
 
     G.write("miles.dot")
     print("Wrote miles.dot")
-    G.draw("miles.png", prog="neato", args="-n2")
+    G.draw("miles.png", prog="nop2")
     print("Wrote miles.png")

--- a/examples/plot_subgraph_boundaries.py
+++ b/examples/plot_subgraph_boundaries.py
@@ -1,0 +1,36 @@
+"""
+Subgraph with Boundaries
+========================
+
+Draw a subgraph with bounding boxes demarcating both the nodes and the subgraphs
+"""
+
+import pygraphviz as pgv
+
+# A graph in `.dot` format specifying two nodes, each within their own subgraph,
+# and a bi-directional edge between them
+dot_str = """
+digraph G {
+    graph [compound=true];
+
+    node [shape=box];
+
+    subgraph cluster_A {
+        label="A";
+        a1 [pos="50,100!"];
+    }
+
+    subgraph cluster_B {
+        label="B";
+        b1 [pos="200,100!"];
+    }
+
+    a1 -> b1 [lhead=cluster_B, ltail=cluster_A, dir=both];
+
+    graph [bb="0,0,300,200"];
+}
+"""
+
+A = pgv.AGraph(dot_str)
+A.layout("dot")
+A.draw("subgraph_bdries.png")

--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -1580,8 +1580,7 @@ class AGraph:
 
         if prog is None:
             if self.has_layout:
-                prog = "neato"
-                args += " -n2"
+                prog = "nop2"
             else:
                 msg = """Graph has no layout information, see layout() or specify prog={}.""".format(
                     "|".join(["neato", "dot", "twopi", "circo", "fdp", "nop"])


### PR DESCRIPTION
Closes #637 

While investigating that issue, I stumbled across [this graphviz discourse post](https://forum.graphviz.org/t/what-is-the-purpose-of-the-n2-option-with-neato/1107) which I think highlights where the issue may lie, and what to do about it[^1].

From my reading - the intended purpose of `neato -n2` is to trigger the rendering engine for drawing *without* modifying the node/edge layout at all. This appeared to work okay with the `neato` CLI, which is what was called in pygraphviz<2.0. As of 2.0 however, we made the switch to rendering via the library interface - and there appear to be subtle changes with how well/whether the `-n2` flag is followed. This is highlighted not only by #637, but I also noticed that the Knuth miles example in the gallery is rotated 180 degrees compared to it's original (i.e. pygraphviz<2.0) orientation.

The fix for both cases is to replace the `"neato -n2"` incantation with `"nop2"`, which AIUI is a sentinel "layout" primarily designed *only* to trigger the rendering engine without messing with node/edge layouts at all.

FWIW I do not think this behavior was/is reliably tested, but I did add the example from #637 to the gallery to at least visually confirm the expected outcome. I'd like to add `pytest-mpl` for more rigorous testing for rendering regressions, but will do so in a follow-up PR when I have time!

[^1]: The last response in that thread (from Apr 2022) provides background for why things are the way they are.