### PR TITLE
Fix graph-level attribute masking node/edge default (gh-563)

### DIFF
--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -1939,10 +1939,12 @@ class Attribute(MutableMapping):
             )
 
     def __getitem__(self, name):
-        item = gv.agget(self.handle, name.encode(self.encoding))
-        if item is None:
-            ah = gv.agattr(self.handle, self.type, name.encode(self.encoding), None)
-            item = gv.agattrdefval(ah)
+        # Look up the default value directly via ``agattr``/``agattrdefval``
+        # rather than ``agget``.  ``agget`` returns "" (not None) when a
+        # same-named attribute is defined at the graph level, which would mask
+        # the node/edge default (see gh-563).  This mirrors ``iteritems``.
+        ah = gv.agattr(self.handle, self.type, name.encode(self.encoding), None)
+        item = gv.agattrdefval(ah)
         return item.decode(self.encoding)
 
     def __delitem__(self, name):

--- a/pygraphviz/agraph.py
+++ b/pygraphviz/agraph.py
@@ -1939,10 +1939,6 @@ class Attribute(MutableMapping):
             )
 
     def __getitem__(self, name):
-        # Look up the default value directly via ``agattr``/``agattrdefval``
-        # rather than ``agget``.  ``agget`` returns "" (not None) when a
-        # same-named attribute is defined at the graph level, which would mask
-        # the node/edge default (see gh-563).  This mirrors ``iteritems``.
         ah = gv.agattr(self.handle, self.type, name.encode(self.encoding), None)
         item = gv.agattrdefval(ah)
         return item.decode(self.encoding)

--- a/pygraphviz/tests/test_attribute_defaults.py
+++ b/pygraphviz/tests/test_attribute_defaults.py
@@ -83,3 +83,13 @@ def test_edge_defaults():
     del A.edge_attr["label"]
     ans = """strict graph { }"""
     assert stringify(A) == " ".join(ans.split())
+
+
+def test_default_not_masked_by_graph_attribute():
+    # See gh-563: an attribute set at the graph level (e.g. via a subgraph)
+    # must not mask a same-named node/edge default.
+    A = pgv.AGraph("digraph { edge[penwidth=2]; subgraph { penwidth=1; } }")
+    assert A.edge_attr["penwidth"] == "2"
+
+    A = pgv.AGraph("digraph { node[shape=box]; subgraph { shape=circle; } }")
+    assert A.node_attr["shape"] == "box"


### PR DESCRIPTION
## Summary

Fixes #563.

`AGraph.edge_attr` / `node_attr` returned `''` instead of the real default when a same-named attribute was also set at the graph level, e.g. via a subgraph:

```python
>>> from pygraphviz import AGraph
>>> g = AGraph("digraph { edge[penwidth=2]; subgraph { penwidth=1; } }")
>>> g.edge_attr['penwidth']
''          # was '' — expected '2'
```

## Fix

`Attribute.__getitem__` looked the value up with `gv.agget(self.handle, name)`. When a same-named attribute exists at the graph level, `agget` returns `""` (an empty string, not `None`), so the existing `if item is None:` fallback never fired and the empty string masked the node/edge default.

The fix reads the default value directly via `gv.agattr(...)` + `gv.agattrdefval(...)`, which is exactly what the `iteritems()` iterator already does for these default-attribute maps. Behavior for graph attributes and for missing keys (which still raise `KeyError`) is unchanged.

## Tests

Added `test_default_not_masked_by_graph_attribute` in `pygraphviz/tests/test_attribute_defaults.py`, covering both the edge and node cases. It fails on `main` (`assert '' == '2'`) and passes with the fix. The full test suite (151 passed, 1 skipped) and module doctests remain green, and `ruff format` reports both changed files already formatted.

Disclosure: prepared with AI assistance; reviewed and verified locally.
